### PR TITLE
Allow the package to be required directly to `template`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Here's an example webpack config illustrating how to use these options in your `
     new HtmlWebpackPlugin({
       // Required
       inject: false,
-      template: 'node_modules/html-webpack-template/index.ejs',
+      template: require('html-webpack-template'),
+      //template: 'node_modules/html-webpack-template/index.ejs',
 
       // Optional
       appMountId: 'app',

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('path').join(__dirname, 'index.ejs');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "html-webpack-template",
   "version": "4.0.0",
   "description": "A template with more features than the default html-webpack-plugin template",
-  "main": "index.ejs",
+  "main": "index.js",
   "scripts": {
     "commit": "git-cz",
     "test": "echo \"Everything is fine.  No tests here.\" && exit 0",


### PR DESCRIPTION
`template: require('html-webpack-template')` should work now.

Closes #9.
