### PR TITLE
correctly resolve for babel-loader in example

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -1,3 +1,4 @@
+var path = require('path')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = {
@@ -8,6 +9,7 @@ module.exports = {
     path: __dirname + '/dist',
     filename: 'main.js'
   },
+  resolveLoader: { root: path.join(__dirname, 'node_modules') },
   module: {
     loaders: [
       { test: /\.js$/, loader: 'babel-loader' }


### PR DESCRIPTION
As per the [webpack documentation](https://webpack.github.io/docs/configuration.html#module-loaders), `node_modules` is expected to be in the parent folder of `webpack.config.js`. Without this change, when I tried to run the project's example I got the following error:

``` sh
    ERROR in ./~/html-webpack-plugin/lib/loader.js!../index.ejs
    Module not found: Error: Cannot resolve module 'babel-loader' in /Users/rbose85/Code/opensrc/html-webpack-template
     @ ./~/html-webpack-plugin/lib/loader.js!../index.ejs 1:8-92
```
