### PR TITLE
Add support for external script tags

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -53,6 +53,10 @@
 </script>
 <% } %>
 
+<% for (var script of htmlWebpackPlugin.options.scripts) { %>
+<script src="<%= script %>"></script>
+<% } %>
+
 <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
 <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
 <% } %>


### PR DESCRIPTION
This PR uses a `scripts` to which you can pass an Array of URLs to add as script tags in the HTML output.

This comes handy for loading external libraries that you can't load as a Webpack entry point, such as Google Maps API.

Example usage:

``` js
new HtmlWebpackPlugin({
      template: 'node_modules/html-webpack-template/index.ejs',
      inject: false,
      title: process.env.APP_NAME,
      appMountId: 'app',
      mobile: true,
      scripts: [
          `https://maps.googleapis.com/maps/api/js?v=3&key=${process.env.GOOGLE_API_KEY}`
      ]
})
```
