### PR TITLE
Add support for prepending url to scripts output url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,19 @@ There are a couple required parameters:
 
 And some other optional:
 
-- `appMountId`: div element id on which you plan to mount a javascript app (can include multiple elements using the `appMountIds` array)
-- `devServer`: insert the webpack-dev-server hot reload script at this host:port/path (eg, http://localhost:3000)
-- `baseHref`: Adjust the url for relative urls in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base))
+- `appMountId`: div element id on which you plan to mount a javascript app (can include multiple elements using the `appMountIds` array).
+- `devServer`: insert the webpack-dev-server hot reload script at this host:port/path (eg, http://localhost:3000).
+- `baseHref`: Adjust the url for relative urls in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base)).
 - `filename`: The file to write the HTML to. Defaults to `index.ejs`.
    You can specify a subdirectory here too (eg: `assets/admin.html`).
 - `googleAnalytics.trackingId`: Track usage of your site via [Google Analytics](http://analytics.google.com).
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
-- `meta`: object that defines the meta tags
+- `meta`: object that defines the meta tags.
 - `mobile`: Sets appropriate meta tags for page scaling.
-- `scripts`: array of external script imports to include on page
+- `prependUrl`: string that defines the url to prepend to urls in document.
+- `scripts`: array of external script imports to include on page.
 - `title`: The title to use for the generated HTML document.
-- `window`: object that defines data you need to bootstrap a javascript app
+- `window`: object that defines data you need to bootstrap a javascript app.
 
 
 Plus any [html-webpack-plugin config options](https://github.com/ampedandwired/html-webpack-plugin#configuration) otherwise available.
@@ -65,6 +66,7 @@ Here's an example webpack config illustrating how to use these options in your `
         description: "a better default template for html-webpack-plugin"
       },
       mobile: true,
+      prependUrl: '/assets/',
       scripts: [
         'http://somecool.com/script.js'
       ],

--- a/index.ejs
+++ b/index.ejs
@@ -6,6 +6,7 @@
 <!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
+  <% var prependUrl = htmlWebpackPlugin.options.prependUrl || '' %>
   <% if (htmlWebpackPlugin.options.meta) { %>
   <% for (var key in htmlWebpackPlugin.options.meta) { %>
   <meta name="<%= key %>" content="<%= htmlWebpackPlugin.options.meta[key] %>">
@@ -22,7 +23,7 @@
   <% } %>
 
   <% for (var css in htmlWebpackPlugin.files.css) { %>
-  <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
+  <link href="<%=prependUrl%><%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
   <% } %>
 
   <% if (htmlWebpackPlugin.options.baseHref) { %>
@@ -66,7 +67,7 @@
 <% } %>
 
 <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
-<script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+<script src="<%=prependUrl%><%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
 <% } %>
 
 <% if (htmlWebpackPlugin.options.devServer) { %>


### PR DESCRIPTION
I found a scenario where you need to prepend url to output assets url without touching the baseHref on document.

Output example :

**`<link href="src.4b3697e6ebd39ce5cf64.css" rel="stylesheet">`**

With **prependUrl** option set to **'/assets/'** :

**`<link href="/assets/src.4b3697e6ebd39ce5cf64.css" rel="stylesheet">`**
