### PR TITLE
Added links attribute to optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ And some other optional:
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
 - `meta`: Object that defines the meta tags.
 - `mobile`: Sets appropriate meta tags for page scaling.
+- `links`: Array of external css imports to include on page.
 - `scripts`: Array of external script imports to include on page.
 - `title`: The title to use for the generated HTML document.
 - `window`: Object that defines data you need to bootstrap a javascript app.
@@ -65,6 +66,9 @@ Here's an example webpack config illustrating how to use these options in your `
         description: "a better default template for html-webpack-plugin"
       },
       mobile: true,
+      links: [
+        'https://fonts.googleapis.com/css?family=Roboto"'
+      ],
       scripts: [
         'http://somecool.com/script.js'
       ],

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
         trackingId: 'UA-XXXX-XX',
         pageViewOnLoad: true
       },
+      links: [ 'https://fonts.googleapis.com/css?family=Roboto"' ],
       scripts: [ 'http://example.com/somescript.js' ],
       devServer: 'http://localhost:3001',
       appMountId: 'app',

--- a/index.ejs
+++ b/index.ejs
@@ -21,6 +21,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <% } %>
 
+  <% if (htmlWebpackPlugin.options.links) { %>
+  <% for (var link of htmlWebpackPlugin.options.links) { %>
+  <link href="<%= link %>" rel="stylesheet">
+  <% } %>
+  <% } %>
+
   <% for (var css in htmlWebpackPlugin.files.css) { %>
   <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
   <% } %>


### PR DESCRIPTION
Hi, I would like the ability to add external css from cdn's to html-webpack-template.

I added a 'links' attribute where you can add external css (from cdn's), such as fonts or frameworks (jquery, bootstrap, …). Then the link tags are printed in the header before the link tags generated by webpack. I do it before the generated css, assuming one uses the css from cdn's as a basis to build upon.

So, this is my first github pull request, so if I made a newbie mistake somewhere, feel free to point it out.

Thanks a lot,
Joachim
