### PR TITLE
Allow the app mount element to be configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ And some other optional:
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
 - `meta`: Object that defines the meta tags.
 - `mobile`: Sets appropriate meta tags for page scaling.
-- `links`: Array of external `<link >` imports to include on page.
-  - If the array value is a string, the value is assigned to the `href` attribute and the `rel` attribute is set to `stylesheet`
-  - If the array value is an object, the object's properties and values are used as the attribute names and values.
+- `links`: Array of `<link >` elements.
+  - If an array element is a string, the value is assigned to the `href` attribute and the `rel` attribute is set to `"stylesheet"`;
+  - If an array element is an object, the object's properties and values are used as the attribute names and values, respectively.
 - `scripts`: Array of external script imports to include on page.
 - `title`: The title to use for the generated HTML document.
 - `window`: Object that defines data you need to bootstrap a javascript app.
@@ -69,7 +69,7 @@ Here's an example webpack config illustrating how to use these options in your `
       },
       mobile: true,
       links: [
-        'https://fonts.googleapis.com/css?family=Roboto"',
+        'https://fonts.googleapis.com/css?family=Roboto',
         {
           rel: 'apple-touch-icon',
           sizes: '180x180',

--- a/README.md
+++ b/README.md
@@ -29,12 +29,17 @@ There are a couple required parameters:
 
 And some other optional:
 
-- `appMountId`: The `<div>` element id on which you plan to mount a JavaScript app (can include multiple elements using
-                the `appMountIds` array).
+- `appMountElement`: The HTML element name to use as the application element(s). Default value: `'div'`.
+- `appMountId`: The application element id on which you plan to mount a JavaScript app. The value of this option is
+  prepended to the `appMountIds` option. See `appMountIds` for possible values.
+- `appMountIds`: An array of application element ids or objects.
+  - If an array element is a string, the value is assigned to the `id` attribute;
+  - If an array element is an object, the object's properties and values are used as the attribute names and values,
+    respectively.
 - `devServer`: Insert the webpack-dev-server hot reload script at this host:port/path; e.g., http://localhost:3000.
 - `baseHref`: Adjust the URL for relative URLs in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base)).
 - `filename`: The file to write the HTML to. Defaults to `index.ejs`. You can specify a subdirectory here too; e.g.,
-              `assets/admin.html`.
+  `assets/admin.html`.
 - `googleAnalytics.trackingId`: Track usage of your site via [Google Analytics](http://analytics.google.com).
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
 - `links`: Array of `<link>` elements. Default value: `[]`.
@@ -70,6 +75,7 @@ Here's an example webpack config illustrating how to use these options in your `
       // template: 'node_modules/html-webpack-template/index.ejs',
 
       // Optional
+      appMountElement: 'article',
       appMountId: 'app',
       baseHref: 'http://example.com/awesome',
       devServer: 3001,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # HTML Webpack Template
 
-This is a template for the [webpack](http://webpack.github.io/) plugin [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin).  It has a few extra features than the [default template](https://github.com/ampedandwired/html-webpack-plugin/blob/master/default_index.html) which will hopefully make it less likely that you'll have to create your own `index.html` file in your webpack project.
+This is a template for the [webpack](http://webpack.github.io/) plugin [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin).
+It has a few extra features than the [default template](https://github.com/ampedandwired/html-webpack-plugin/blob/master/default_index.html)
+which will hopefully make it less likely that you'll have to create your own `index.html` file in your webpack project.
 
-Templates for the html-webpack-plugin are implemented using [underscore templates](http://underscorejs.org/#template) (previously, in 2.x, [blueimp templates](https://github.com/blueimp/JavaScript-Templates)).  You can write your own as well.
+Templates for the html-webpack-plugin are implemented using [underscore templates](http://underscorejs.org/#template)
+(previously, in 2.x, [blueimp templates](https://github.com/blueimp/JavaScript-Templates)). You can write your own as
+well.
 
 #### Legacy version
 
@@ -20,29 +24,32 @@ $ npm install html-webpack-template --save-dev
 
 There are a couple required parameters:
 
-- `inject`: Set to `false`.  Controls asset addition to the template.  This template takes care of that.
-- `template`: Specify this module's `index.ejs` file
+- `inject`: Set to `false`. Controls asset addition to the template. This template takes care of that.
+- `template`: Specify this module's `index.ejs` file.
 
 And some other optional:
 
-- `appMountId`: div element id on which you plan to mount a javascript app (can include multiple elements using the `appMountIds` array).
-- `devServer`: Insert the webpack-dev-server hot reload script at this host:port/path (eg, http://localhost:3000).
-- `baseHref`: Adjust the url for relative urls in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base)).
-- `filename`: The file to write the HTML to. Defaults to `index.ejs`.
-   You can specify a subdirectory here too (eg: `assets/admin.html`).
+- `appMountId`: The `<div>` element id on which you plan to mount a JavaScript app (can include multiple elements using
+                the `appMountIds` array).
+- `devServer`: Insert the webpack-dev-server hot reload script at this host:port/path; e.g., http://localhost:3000.
+- `baseHref`: Adjust the URL for relative URLs in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base)).
+- `filename`: The file to write the HTML to. Defaults to `index.ejs`. You can specify a subdirectory here too; e.g.,
+              `assets/admin.html`.
 - `googleAnalytics.trackingId`: Track usage of your site via [Google Analytics](http://analytics.google.com).
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
-- `meta`: Object that defines the meta tags.
-- `mobile`: Sets appropriate meta tags for page scaling.
-- `links`: Array of `<link >` elements.
+- `links`: Array of `<link>` elements. Default value: `[]`.
   - If an array element is a string, the value is assigned to the `href` attribute and the `rel` attribute is set to `"stylesheet"`;
   - If an array element is an object, the object's properties and values are used as the attribute names and values, respectively.
-- `scripts`: Array of external script imports to include on page.
-- `title`: The title to use for the generated HTML document.
-- `window`: Object that defines data you need to bootstrap a javascript app.
+- `meta`: Object that defines the meta tags. Default value: `{}`.
+- `mobile`: Sets appropriate meta tag for page scaling.
+- `scripts`: Array of external script imports to include on page. Default value: `[]`.
+- `title`: The title to use for the generated HTML document. Default value: `'Webpack App'`.
+- `window`: Object that defines data you need to bootstrap a JavaScript app.
 
+Plus any [html-webpack-plugin config options](https://github.com/ampedandwired/html-webpack-plugin#configuration)
+otherwise available.
 
-Plus any [html-webpack-plugin config options](https://github.com/ampedandwired/html-webpack-plugin#configuration) otherwise available.
+### Example
 
 Here's an example webpack config illustrating how to use these options in your `webpack.config.js`:
 
@@ -54,7 +61,7 @@ Here's an example webpack config illustrating how to use these options in your `
       // Required
       inject: false,
       template: require('html-webpack-template'),
-      //template: 'node_modules/html-webpack-template/index.ejs',
+      // template: 'node_modules/html-webpack-template/index.ejs',
 
       // Optional
       appMountId: 'app',
@@ -65,7 +72,7 @@ Here's an example webpack config illustrating how to use these options in your `
         pageViewOnLoad: true
       },
       meta: {
-        description: "a better default template for html-webpack-plugin"
+        description: 'A better default template for html-webpack-plugin.'
       },
       mobile: true,
       links: [
@@ -91,7 +98,7 @@ Here's an example webpack config illustrating how to use these options in your `
         }
       }
 
-      // and any other config options from html-webpack-plugin
+      // And any other config options from html-webpack-plugin:
       // https://github.com/ampedandwired/html-webpack-plugin#configuration
     })
   ]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Here's an example webpack config illustrating how to use these options in your `
       appMountElement: 'article',
       appMountId: 'app',
       baseHref: 'http://example.com/awesome',
-      devServer: 3001,
+      devServer: 'http://localhost:3001',
       googleAnalytics: {
         trackingId: 'UA-XXXX-XX',
         pageViewOnLoad: true
@@ -102,7 +102,7 @@ Here's an example webpack config illustrating how to use these options in your `
         }
       ],
       scripts: [
-        'http://somecool.com/script.js',
+        'http://example.com/somescript.js',
         {
           crossorigin: 'anonymous',
           integrity: 'sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=',
@@ -110,6 +110,7 @@ Here's an example webpack config illustrating how to use these options in your `
           type: 'text/javascript'
         }
       ],
+      title: 'My App',
       window: {
         env: {
           apiHost: 'http://myapi.com/api/v1'

--- a/README.md
+++ b/README.md
@@ -38,11 +38,17 @@ And some other optional:
 - `googleAnalytics.trackingId`: Track usage of your site via [Google Analytics](http://analytics.google.com).
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
 - `links`: Array of `<link>` elements. Default value: `[]`.
-  - If an array element is a string, the value is assigned to the `href` attribute and the `rel` attribute is set to `"stylesheet"`;
-  - If an array element is an object, the object's properties and values are used as the attribute names and values, respectively.
+  - If an array element is a string, the value is assigned to the `href` attribute and the `rel` attribute is set to
+    `"stylesheet"`;
+  - If an array element is an object, the object's properties and values are used as the attribute names and values,
+    respectively.
 - `meta`: Object that defines the meta tags. Default value: `{}`.
 - `mobile`: Sets appropriate meta tag for page scaling.
 - `scripts`: Array of external script imports to include on page. Default value: `[]`.
+  - If an array element is a string, the value is assigned to the `src` attribute and the `type` attribute is set to
+    `"text/javascript"`;
+  - If an array element is an object, the object's properties and values are used as the attribute names and values,
+    respectively.
 - `title`: The title to use for the generated HTML document. Default value: `'Webpack App'`.
 - `window`: Object that defines data you need to bootstrap a JavaScript app.
 
@@ -78,19 +84,25 @@ Here's an example webpack config illustrating how to use these options in your `
       links: [
         'https://fonts.googleapis.com/css?family=Roboto',
         {
+          href: '/apple-touch-icon.png',
           rel: 'apple-touch-icon',
-          sizes: '180x180',
-          href: '/apple-touch-icon.png'
+          sizes: '180x180'
         },
         {
-          rel: 'icon',
-          type: 'image/png',
           href: '/favicon-32x32.png',
-          sizes: '32x32'
+          rel: 'icon',
+          sizes: '32x32',
+          type: 'image/png'
         }
       ],
       scripts: [
-        'http://somecool.com/script.js'
+        'http://somecool.com/script.js',
+        {
+          crossorigin: 'anonymous',
+          integrity: 'sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=',
+          src: 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js',
+          type: 'text/javascript'
+        }
       ],
       window: {
         env: {

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
         pageViewOnLoad: true
       },
       links: [ 
-        'https://fonts.googleapis.com/css?family=Roboto"',
+        'https://fonts.googleapis.com/css?family=Roboto',
         {
           rel: 'apple-touch-icon',
           sizes: '180x180',

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -31,21 +31,29 @@ module.exports = {
         trackingId: 'UA-XXXX-XX',
         pageViewOnLoad: true
       },
-      links: [ 
+      links: [
         'https://fonts.googleapis.com/css?family=Roboto',
         {
+          href: '/apple-touch-icon.png',
           rel: 'apple-touch-icon',
-          sizes: '180x180',
-          href: '/apple-touch-icon.png'
+          sizes: '180x180'
         },
         {
-          rel: 'icon',
-          type: 'image/png',
           href: '/favicon-32x32.png',
-          sizes: '32x32'
-        } 
+          rel: 'icon',
+          sizes: '32x32',
+          type: 'image/png'
+        }
       ],
-      scripts: [ 'http://example.com/somescript.js' ],
+      scripts: [
+        'http://example.com/somescript.js',
+        {
+          crossorigin: 'anonymous',
+          integrity: 'sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=',
+          src: 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js',
+          type: 'text/javascript'
+        }
+      ],
       devServer: 'http://localhost:3001',
       appMountId: 'app',
       window: {

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
         }
       ],
       devServer: 'http://localhost:3001',
+      appMountElement: 'article',
       appMountId: 'app',
       window: {
         env: {

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -22,15 +22,17 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: false,
       template: '../index.ejs',
-      title: 'My App',
-      meta: {
-        description: "a better default template for html-webpack-plugin"
-      },
-      mobile: true,
+      appMountElement: 'article',
+      appMountId: 'app',
+      devServer: 'http://localhost:3001',
       googleAnalytics: {
         trackingId: 'UA-XXXX-XX',
         pageViewOnLoad: true
       },
+      meta: {
+        description: 'A better default template for html-webpack-plugin.'
+      },
+      mobile: true,
       links: [
         'https://fonts.googleapis.com/css?family=Roboto',
         {
@@ -54,9 +56,7 @@ module.exports = {
           type: 'text/javascript'
         }
       ],
-      devServer: 'http://localhost:3001',
-      appMountElement: 'article',
-      appMountId: 'app',
+      title: 'My App',
       window: {
         env: {
           apiHost: 'http://myapi.com/api/v1'

--- a/index.ejs
+++ b/index.ejs
@@ -15,7 +15,7 @@
 <% var chunks = files.chunks %>
 <% var devServer = options.devServer %>
 <% var googleAnalytics = options.googleAnalytics %>
-<% var trackingId = googleAnalytics.trackingId %>
+<% var trackingId = googleAnalytics && googleAnalytics.trackingId %>
 
 <!DOCTYPE html>
 <!--[if lt IE 7 ]>             <html lang="en" class="ie6"<% if (manifest) { %> manifest="<%= manifest %>"<% } %>> <![endif]-->
@@ -25,9 +25,9 @@
 <!--[if (gt IE 9)|!(IE)]><!--> <html lang="en"<% if (manifest) { %> manifest="<%= manifest %>"<% } %>> <!--<![endif]-->
   <head>
     <meta charset="utf-8">
-    <% if (htmlWebpackPlugin.options.mobile) { %>
-    <meta content="width=device-width, initial-scale=1" name="viewport">
-    <% } %>
+    <meta content="ie=edge" http-equiv="x-ua-compatible">
+
+    <title><%= title %></title>
 
     <% if (meta) { %>
     <% for (key in meta) { %>
@@ -35,7 +35,9 @@
     <% } %>
     <% } %>
 
-    <title><%= title %></title>
+    <% if (options.mobile) { %>
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <% } %>
 
     <% if (favicon) { %>
     <link href="<%= favicon %>" rel="shortcut icon">
@@ -67,7 +69,7 @@
     <% if (options.unsupportedBrowser) { %>
     <style>.unsupported-browser { display: none; }</style>
     <div class="unsupported-browser">
-      Sorry, your browser is not supported.  Please upgrade to the latest version or switch your browser to use this
+      Sorry, your browser is not supported. Please upgrade to the latest version or switch your browser to use this
       site. See <a href="http://outdatedbrowser.com/">outdatedbrowser.com</a> for options.
     </div>
     <% } %>
@@ -76,14 +78,14 @@
     <div id="<%= appMountId %>"></div>
     <% } %>
 
-    <% if (appMountIds && appMountIds.length > 0) { %>
+    <% if (appMountIds) { %>
     <% for (item of appMountIds) { %>
     <div id="<%= item %>"></div>
     <% } %>
     <% } %>
 
     <% if (globals) { %>
-    <script>
+    <script type="text/javascript">
       <% for (key in globals) { %>
       window['<%= key %>'] = <%= JSON.stringify(globals[key]) %>;
       <% } %>
@@ -92,26 +94,26 @@
 
     <% if (scripts) { %>
     <% for (item of scripts) { %>
-    <script src="<%= item %>"></script>
+    <script src="<%= item %>" type="text/javascript"></script>
     <% } %>
     <% } %>
 
     <% for (key in chunks) { %>
-    <script src="<%= chunks[key].entry %>"></script>
+    <script src="<%= chunks[key].entry %>" type="text/javascript"></script>
     <% } %>
 
     <% if (devServer) { %>
-    <script src="<%= devServer %>/webpack-dev-server.js"></script>
+    <script src="<%= devServer %>/webpack-dev-server.js" type="text/javascript"></script>
     <% } %>
 
     <% if (googleAnalytics) { %>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <script type="text/javascript">
+      !function(o,n,f,a,t,e,r){o.GoogleAnalyticsObject=t,o[t]=o[t]||function(){(o[t].q=o[t].q||[]).push(arguments)},o[t].l=1*new Date,e=n.createElement(f),r=n.getElementsByTagName(f)[0],e.async=1,e.src=a,r.parentNode.insertBefore(e,r)}(window,document,"script","//www.google-analytics.com/analytics.js","ga")
       <% if (trackingId) { %>
-      ga('create', '<%= trackingId %>', 'auto');
+      ga("create","<%= trackingId %>","auto")
       <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); }%>
       <% if (googleAnalytics.pageViewOnLoad) { %>
-      ga('send', 'pageview');
+      ga("send","pageview")
       <% } %>
     </script>
     <% } %>

--- a/index.ejs
+++ b/index.ejs
@@ -42,15 +42,8 @@
     <% } %>
 
     <% for (item of links) { %>
-    <% if (item && typeof item === 'object') { %>
-  	<link
-  	  <% for (key in item) { %>
-      <%= key %>="<%= item[key] %>"
-      <% } %>
-    >
-    <% } else { %>
-    <link href="<%= item %>" rel="stylesheet">
-    <% } %>
+    <% if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } %>
+  	<link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
     <% } %>
 
     <% for (key in css) { %>
@@ -87,7 +80,8 @@
     <% } %>
 
     <% for (item of scripts) { %>
-    <script src="<%= item %>" type="text/javascript"></script>
+    <% if (typeof item === 'string' || item instanceof String) { item = { src: item, type: 'text/javascript' } } %>
+    <script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script>
     <% } %>
 
     <% for (key in chunks) { %>

--- a/index.ejs
+++ b/index.ejs
@@ -1,108 +1,100 @@
 <!DOCTYPE html>
-<!--[if lt IE 7 ]> <html lang="en" class="ie6" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <!--<![endif]-->
-<head>
-  <meta charset="utf-8">
-  <% if (htmlWebpackPlugin.options.meta) { %>
-  <% for (var key in htmlWebpackPlugin.options.meta) { %>
-  <meta name="<%= key %>" content="<%= htmlWebpackPlugin.options.meta[key] %>">
-  <% } %>
-  <% } %>
-
-  <title><%= htmlWebpackPlugin.options.title || 'Webpack App'%></title>
-
-  <% if (htmlWebpackPlugin.files.favicon) { %>
-  <link rel="shortcut icon" href="<%= htmlWebpackPlugin.files.favicon%>">
-  <% } %>
-  <% if (htmlWebpackPlugin.options.mobile) { %>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <% } %>
-
-  <% if (htmlWebpackPlugin.options.links) { %>
-  <% for(var link of htmlWebpackPlugin.options.links) { %>
-  <% if (link !== null && typeof link === 'object' ) { %>
-  <link
-    <% for (var key in link) { %>
-    <%= key %>="<%= link[key] %>"
+<!--[if lt IE 7 ]>             <html lang="en" class="ie6"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
+<!--[if IE 7 ]>                <html lang="en" class="ie7"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
+<!--[if IE 8 ]>                <html lang="en" class="ie8"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
+<!--[if IE 9 ]>                <html lang="en" class="ie9"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <!--<![endif]-->
+  <head>
+    <meta charset="utf-8">
+    <% if (htmlWebpackPlugin.options.mobile) { %>
+    <meta content="width=device-width, initial-scale=1" name="viewport">
     <% } %>
-  >
-  <% } else { %>
+
+    <% if (htmlWebpackPlugin.options.meta) { %>
+    <% for (var key in htmlWebpackPlugin.options.meta) { %>
+    <meta content="<%= htmlWebpackPlugin.options.meta[key] %>" name="<%= key %>">
+    <% } %>
+    <% } %>
+
+    <title><%= htmlWebpackPlugin.options.title || 'Webpack App' %></title>
+
+    <% if (htmlWebpackPlugin.files.favicon) { %>
+    <link href="<%= htmlWebpackPlugin.files.favicon %>" rel="shortcut icon">
+    <% } %>
+
+    <% if (htmlWebpackPlugin.options.links) { %>
+    <% for (var link of htmlWebpackPlugin.options.links) { %>
+    <% if (link && typeof link === 'object') { %>
+  	<link
+  	  <% for (var key in link) { %>
+      <%= key %>="<%= link[key] %>"
+      <% } %>
+    >
+    <% } else { %>
     <link href="<%= link %>" rel="stylesheet">
-  <% } %>
-  <% } %>
-  <% } %>
+    <% } %>
+    <% } %>
+    <% } %>
 
-  <% for (var css in htmlWebpackPlugin.files.css) { %>
-  <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
-  <% } %>
+    <% for (var css in htmlWebpackPlugin.files.css) { %>
+    <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
+    <% } %>
 
-  <% if (htmlWebpackPlugin.options.baseHref) { %>
-  <base href="<%= htmlWebpackPlugin.options.baseHref %>" />
-  <% } %>
+    <% if (htmlWebpackPlugin.options.baseHref) { %>
+    <base href="<%= htmlWebpackPlugin.options.baseHref %>">
+    <% } %>
+  </head>
+  <body>
+    <% if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
+    <style>.unsupported-browser { display: none; }</style>
+    <div class="unsupported-browser">
+      Sorry, your browser is not supported.  Please upgrade to the latest version or switch your browser to use this
+      site. See <a href="http://outdatedbrowser.com/">outdatedbrowser.com</a> for options.
+    </div>
+    <% } %>
 
-</head>
-<body>
-<% if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
-<style>.unsupported-browser { display: none; }</style>
-<div class="unsupported-browser">
-  Sorry, your browser is not supported.  Please upgrade to
-  the latest version or switch your browser to use this site.
-  See <a href="http://outdatedbrowser.com/">outdatedbrowser.com</a>
-  for options.
-</div>
-<% } %>
+    <% if (htmlWebpackPlugin.options.appMountId) { %>
+    <div id="<%= htmlWebpackPlugin.options.appMountId %>"></div>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.appMountId) { %>
-<div id="<%= htmlWebpackPlugin.options.appMountId%>"></div>
-<% } %>
+    <% if (htmlWebpackPlugin.options.appMountIds && htmlWebpackPlugin.options.appMountIds.length > 0) { %>
+    <% for (var index in htmlWebpackPlugin.options.appMountIds) { %>
+    <div id="<%= htmlWebpackPlugin.options.appMountIds[index] %>"></div>
+    <% } %>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.appMountIds && htmlWebpackPlugin.options.appMountIds.length > 0) { %>
-<% for (var index in htmlWebpackPlugin.options.appMountIds) { %>
-<div id="<%= htmlWebpackPlugin.options.appMountIds[index]%>"></div>
-<% } %>
-<% } %>
+    <% if (htmlWebpackPlugin.options.window) { %>
+    <script>
+      <% for (var varName in htmlWebpackPlugin.options.window) { %>
+      window['<%= varName %>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[varName]) %>;
+      <% } %>
+    </script>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.window) { %>
-<script>
-  <% for (var varName in htmlWebpackPlugin.options.window) { %>
-    window['<%=varName%>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[varName]) %>;
-  <% } %>
-</script>
-<% } %>
+    <% if (htmlWebpackPlugin.options.scripts) { %>
+    <% for (var script of htmlWebpackPlugin.options.scripts) { %>
+    <script src="<%= script %>"></script>
+    <% } %>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.scripts) { %>
-<% for (var script of htmlWebpackPlugin.options.scripts) { %>
-<script src="<%= script %>"></script>
-<% } %>
-<% } %>
+    <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
+    <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+    <% } %>
 
-<% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
-<script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
-<% } %>
+    <% if (htmlWebpackPlugin.options.devServer) { %>
+    <script src="<%= htmlWebpackPlugin.options.devServer %>/webpack-dev-server.js"></script>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.devServer) { %>
-<script src="<%= htmlWebpackPlugin.options.devServer%>/webpack-dev-server.js"></script>
-<% } %>
-
-<% if (htmlWebpackPlugin.options.googleAnalytics) { %>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-
-  <% if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
-    ga('create', '<%= htmlWebpackPlugin.options.googleAnalytics.trackingId%>', 'auto');
-    <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); }%>
-
-  <% if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
-    ga('send', 'pageview');
-  <% } %>
-</script>
-<% } %>
-</body>
+    <% if (htmlWebpackPlugin.options.googleAnalytics) { %>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      <% if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
+      ga('create', '<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>', 'auto');
+      <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); }%>
+      <% if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
+      ga('send', 'pageview');
+      <% } %>
+    </script>
+    <% } %>
+  </body>
 </html>

--- a/index.ejs
+++ b/index.ejs
@@ -2,16 +2,16 @@
 <% var files = htmlWebpackPlugin.files %>
 <% var options = htmlWebpackPlugin.options %>
 <% var manifest = files.manifest %>
-<% var meta = options.meta %>
+<% var meta = options.meta || {} %>
 <% var title = options.title || 'Webpack App' %>
 <% var favicon = files.favicon %>
-<% var links = options.links %>
+<% var links = options.links || [] %>
 <% var css = files.css %>
 <% var baseHref = options.baseHref %>
 <% var appMountId = options.appMountId %>
-<% var appMountIds = options.appMountIds %>
+<% var appMountIds = options.appMountIds || [] %>
 <% var globals = options.window %>
-<% var scripts = options.scripts %>
+<% var scripts = options.scripts || [] %>
 <% var chunks = files.chunks %>
 <% var devServer = options.devServer %>
 <% var googleAnalytics = options.googleAnalytics %>
@@ -29,10 +29,8 @@
 
     <title><%= title %></title>
 
-    <% if (meta) { %>
     <% for (key in meta) { %>
     <meta content="<%= meta[key] %>" name="<%= key %>">
-    <% } %>
     <% } %>
 
     <% if (options.mobile) { %>
@@ -43,7 +41,6 @@
     <link href="<%= favicon %>" rel="shortcut icon">
     <% } %>
 
-    <% if (links) { %>
     <% for (item of links) { %>
     <% if (item && typeof item === 'object') { %>
   	<link
@@ -53,7 +50,6 @@
     >
     <% } else { %>
     <link href="<%= item %>" rel="stylesheet">
-    <% } %>
     <% } %>
     <% } %>
 
@@ -78,10 +74,8 @@
     <div id="<%= appMountId %>"></div>
     <% } %>
 
-    <% if (appMountIds) { %>
     <% for (item of appMountIds) { %>
     <div id="<%= item %>"></div>
-    <% } %>
     <% } %>
 
     <% if (globals) { %>
@@ -92,10 +86,8 @@
     </script>
     <% } %>
 
-    <% if (scripts) { %>
     <% for (item of scripts) { %>
     <script src="<%= item %>" type="text/javascript"></script>
-    <% } %>
     <% } %>
 
     <% for (key in chunks) { %>

--- a/index.ejs
+++ b/index.ejs
@@ -63,10 +63,7 @@
     </div>
     <% } %>
 
-    <% if (appMountId) { %>
-    <div id="<%= appMountId %>"></div>
-    <% } %>
-
+    <% if (appMountId) { appMountIds.unshift(appMountId) } %>
     <% for (item of appMountIds) { %>
     <div id="<%= item %>"></div>
     <% } %>

--- a/index.ejs
+++ b/index.ejs
@@ -8,6 +8,7 @@
 <% var links = options.links || [] %>
 <% var css = files.css %>
 <% var baseHref = options.baseHref %>
+<% var appMountElement = options.appMountElement || 'div' %>
 <% var appMountId = options.appMountId %>
 <% var appMountIds = options.appMountIds || [] %>
 <% var globals = options.window %>
@@ -65,7 +66,8 @@
 
     <% if (appMountId) { appMountIds.unshift(appMountId) } %>
     <% for (item of appMountIds) { %>
-    <div id="<%= item %>"></div>
+    <% if (typeof item === 'string' || item instanceof String) { item = { id: item } } %>
+    <<%= appMountElement %><% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></<%= appMountElement %>>
     <% } %>
 
     <% if (globals) { %>

--- a/index.ejs
+++ b/index.ejs
@@ -1,51 +1,70 @@
+<% var item, key %>
+<% var files = htmlWebpackPlugin.files %>
+<% var options = htmlWebpackPlugin.options %>
+<% var manifest = files.manifest %>
+<% var meta = options.meta %>
+<% var title = options.title || 'Webpack App' %>
+<% var favicon = files.favicon %>
+<% var links = options.links %>
+<% var css = files.css %>
+<% var baseHref = options.baseHref %>
+<% var appMountId = options.appMountId %>
+<% var appMountIds = options.appMountIds %>
+<% var globals = options.window %>
+<% var scripts = options.scripts %>
+<% var chunks = files.chunks %>
+<% var devServer = options.devServer %>
+<% var googleAnalytics = options.googleAnalytics %>
+<% var trackingId = googleAnalytics.trackingId %>
+
 <!DOCTYPE html>
-<!--[if lt IE 7 ]>             <html lang="en" class="ie6"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 7 ]>                <html lang="en" class="ie7"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 8 ]>                <html lang="en" class="ie8"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 9 ]>                <html lang="en" class="ie9"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <!--<![endif]-->
+<!--[if lt IE 7 ]>             <html lang="en" class="ie6"<% if (manifest) { %> manifest="<%= manifest %>"<% } %>> <![endif]-->
+<!--[if IE 7 ]>                <html lang="en" class="ie7"<% if (manifest) { %> manifest="<%= manifest %>"<% } %>> <![endif]-->
+<!--[if IE 8 ]>                <html lang="en" class="ie8"<% if (manifest) { %> manifest="<%= manifest %>"<% } %>> <![endif]-->
+<!--[if IE 9 ]>                <html lang="en" class="ie9"<% if (manifest) { %> manifest="<%= manifest %>"<% } %>> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en"<% if (manifest) { %> manifest="<%= manifest %>"<% } %>> <!--<![endif]-->
   <head>
     <meta charset="utf-8">
     <% if (htmlWebpackPlugin.options.mobile) { %>
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.meta) { %>
-    <% for (var key in htmlWebpackPlugin.options.meta) { %>
-    <meta content="<%= htmlWebpackPlugin.options.meta[key] %>" name="<%= key %>">
+    <% if (meta) { %>
+    <% for (key in meta) { %>
+    <meta content="<%= meta[key] %>" name="<%= key %>">
     <% } %>
     <% } %>
 
-    <title><%= htmlWebpackPlugin.options.title || 'Webpack App' %></title>
+    <title><%= title %></title>
 
-    <% if (htmlWebpackPlugin.files.favicon) { %>
-    <link href="<%= htmlWebpackPlugin.files.favicon %>" rel="shortcut icon">
+    <% if (favicon) { %>
+    <link href="<%= favicon %>" rel="shortcut icon">
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.links) { %>
-    <% for (var link of htmlWebpackPlugin.options.links) { %>
-    <% if (link && typeof link === 'object') { %>
+    <% if (links) { %>
+    <% for (item of links) { %>
+    <% if (item && typeof item === 'object') { %>
   	<link
-  	  <% for (var key in link) { %>
-      <%= key %>="<%= link[key] %>"
+  	  <% for (key in item) { %>
+      <%= key %>="<%= item[key] %>"
       <% } %>
     >
     <% } else { %>
-    <link href="<%= link %>" rel="stylesheet">
+    <link href="<%= item %>" rel="stylesheet">
     <% } %>
     <% } %>
     <% } %>
 
-    <% for (var css in htmlWebpackPlugin.files.css) { %>
-    <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
+    <% for (key in css) { %>
+    <link href="<%= css[key] %>" rel="stylesheet">
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.baseHref) { %>
-    <base href="<%= htmlWebpackPlugin.options.baseHref %>">
+    <% if (baseHref) { %>
+    <base href="<%= baseHref %>">
     <% } %>
   </head>
   <body>
-    <% if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
+    <% if (options.unsupportedBrowser) { %>
     <style>.unsupported-browser { display: none; }</style>
     <div class="unsupported-browser">
       Sorry, your browser is not supported.  Please upgrade to the latest version or switch your browser to use this
@@ -53,45 +72,45 @@
     </div>
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.appMountId) { %>
-    <div id="<%= htmlWebpackPlugin.options.appMountId %>"></div>
+    <% if (appMountId) { %>
+    <div id="<%= appMountId %>"></div>
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.appMountIds && htmlWebpackPlugin.options.appMountIds.length > 0) { %>
-    <% for (var index in htmlWebpackPlugin.options.appMountIds) { %>
-    <div id="<%= htmlWebpackPlugin.options.appMountIds[index] %>"></div>
+    <% if (appMountIds && appMountIds.length > 0) { %>
+    <% for (item of appMountIds) { %>
+    <div id="<%= item %>"></div>
     <% } %>
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.window) { %>
+    <% if (globals) { %>
     <script>
-      <% for (var varName in htmlWebpackPlugin.options.window) { %>
-      window['<%= varName %>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[varName]) %>;
+      <% for (key in globals) { %>
+      window['<%= key %>'] = <%= JSON.stringify(globals[key]) %>;
       <% } %>
     </script>
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.scripts) { %>
-    <% for (var script of htmlWebpackPlugin.options.scripts) { %>
-    <script src="<%= script %>"></script>
+    <% if (scripts) { %>
+    <% for (item of scripts) { %>
+    <script src="<%= item %>"></script>
     <% } %>
     <% } %>
 
-    <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
-    <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+    <% for (key in chunks) { %>
+    <script src="<%= chunks[key].entry %>"></script>
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.devServer) { %>
-    <script src="<%= htmlWebpackPlugin.options.devServer %>/webpack-dev-server.js"></script>
+    <% if (devServer) { %>
+    <script src="<%= devServer %>/webpack-dev-server.js"></script>
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.googleAnalytics) { %>
+    <% if (googleAnalytics) { %>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      <% if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
-      ga('create', '<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>', 'auto');
+      <% if (trackingId) { %>
+      ga('create', '<%= trackingId %>', 'auto');
       <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); }%>
-      <% if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
+      <% if (googleAnalytics.pageViewOnLoad) { %>
       ga('send', 'pageview');
       <% } %>
     </script>


### PR DESCRIPTION
**This is based off of #28.**

The `appMountElement` option can be set to the name of an element; e.g. `'article'`. This element is used for all `appMountIds`. This could be expanded in the future to allow the element to be set per id, but that would be best implemented with breaking changes.

The `appMountIds` option, and thus the `appMountId` option, has been modified to be similar to the `links` and `scripts` options.

This enhancement was inspired by #24.
