### PR TITLE
Refactor template.

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -31,7 +31,7 @@
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <% } %>
 
-    <% for (item of links) { %>
+    <% for (item of htmlWebpackPlugin.options.links) { %>
     <% if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } %>
   	<link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
     <% } %>
@@ -80,14 +80,17 @@
 
     <% if (htmlWebpackPlugin.options.googleAnalytics) { %>
     <script type="text/javascript">
-      !function(o,n,f,a,t,e,r){o.GoogleAnalyticsObject=t,o[t]=o[t]||function(){(o[t].q=o[t].q||[]).push(arguments)},o[t].l=1*new Date,e=n.createElement(f),r=n.getElementsByTagName(f)[0],e.async=1,e.src=a,r.parentNode.insertBefore(e,r)}(window,document,"script","//www.google-analytics.com/analytics.js","ga")
+      window.GoogleAnalyticsObject='ga';window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
+
       <% if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
-      ga("create","<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>","auto")
-      <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); }%>
-      <% if (googleAnalytics.pageViewOnLoad) { %>
-      ga("send","pageview")
+      ga('create','<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>','auto');
+      <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); } %>
+
+      <% if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
+      ga('send','pageview')
       <% } %>
     </script>
+    <script async defer src="https://www.google-analytics.com/analytics.js" type="text/javascript"></script>
     <% } %>
   </body>
 </html>

--- a/index.ejs
+++ b/index.ejs
@@ -1,108 +1,93 @@
+<%# Declare temp variables. %>
+<% var item, key %>
+
+<%# Set defaults. %>
+<% htmlWebpackPlugin.options.appMountIds = htmlWebpackPlugin.options.appMountIds || [] %>
+<% htmlWebpackPlugin.options.links = htmlWebpackPlugin.options.links || [] %>
+<% htmlWebpackPlugin.options.meta = htmlWebpackPlugin.options.meta || {} %>
+<% htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || [] %>
+
 <!DOCTYPE html>
-<!--[if lt IE 7 ]> <html lang="en" class="ie6" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="ie7" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="ie8" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if IE 9 ]>    <html lang="en" class="ie9" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="" <% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <!--<![endif]-->
-<head>
-  <meta charset="utf-8">
-  <% if (htmlWebpackPlugin.options.meta) { %>
-  <% for (var key in htmlWebpackPlugin.options.meta) { %>
-  <meta name="<%= key %>" content="<%= htmlWebpackPlugin.options.meta[key] %>">
-  <% } %>
-  <% } %>
+<!--[if lt IE 7 ]>             <html class="ie6" lang="en"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
+<!--[if IE 7 ]>                <html class="ie7" lang="en"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
+<!--[if IE 8 ]>                <html class="ie8" lang="en"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
+<!--[if IE 9 ]>                <html class="ie9" lang="en"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>> <!--<![endif]-->
+  <head>
+    <meta charset="utf-8">
+    <meta content="ie=edge" http-equiv="x-ua-compatible">
 
-  <title><%= htmlWebpackPlugin.options.title || 'Webpack App'%></title>
-
-  <% if (htmlWebpackPlugin.files.favicon) { %>
-  <link rel="shortcut icon" href="<%= htmlWebpackPlugin.files.favicon%>">
-  <% } %>
-  <% if (htmlWebpackPlugin.options.mobile) { %>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <% } %>
-
-  <% if (htmlWebpackPlugin.options.links) { %>
-  <% for(var link of htmlWebpackPlugin.options.links) { %>
-  <% if (link !== null && typeof link === 'object' ) { %>
-  <link
-    <% for (var key in link) { %>
-    <%= key %>="<%= link[key] %>"
+    <% for (key in htmlWebpackPlugin.options.meta) { %>
+    <meta content="<%= htmlWebpackPlugin.options.meta[key] %>" name="<%= key %>">
     <% } %>
-  >
-  <% } else { %>
-    <link href="<%= link %>" rel="stylesheet">
-  <% } %>
-  <% } %>
-  <% } %>
 
-  <% for (var css in htmlWebpackPlugin.files.css) { %>
-  <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
-  <% } %>
+    <title><%= htmlWebpackPlugin.options.title %></title>
 
-  <% if (htmlWebpackPlugin.options.baseHref) { %>
-  <base href="<%= htmlWebpackPlugin.options.baseHref %>" />
-  <% } %>
+    <% if (htmlWebpackPlugin.files.favicon) { %>
+    <link href="<%= htmlWebpackPlugin.files.favicon %>" rel="shortcut icon">
+    <% } %>
 
-</head>
-<body>
-<% if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
-<style>.unsupported-browser { display: none; }</style>
-<div class="unsupported-browser">
-  Sorry, your browser is not supported.  Please upgrade to
-  the latest version or switch your browser to use this site.
-  See <a href="http://outdatedbrowser.com/">outdatedbrowser.com</a>
-  for options.
-</div>
-<% } %>
+    <% if (htmlWebpackPlugin.options.mobile) { %>
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.appMountId) { %>
-<div id="<%= htmlWebpackPlugin.options.appMountId%>"></div>
-<% } %>
+    <% for (item of links) { %>
+    <% if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } %>
+  	<link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.appMountIds && htmlWebpackPlugin.options.appMountIds.length > 0) { %>
-<% for (var index in htmlWebpackPlugin.options.appMountIds) { %>
-<div id="<%= htmlWebpackPlugin.options.appMountIds[index]%>"></div>
-<% } %>
-<% } %>
+    <% for (key in htmlWebpackPlugin.files.css) { %>
+    <link href="<%= htmlWebpackPlugin.files.css[key] %>" rel="stylesheet">
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.window) { %>
-<script>
-  <% for (var varName in htmlWebpackPlugin.options.window) { %>
-    window['<%=varName%>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[varName]) %>;
-  <% } %>
-</script>
-<% } %>
+    <% if (htmlWebpackPlugin.options.baseHref) { %>
+    <base href="<%= htmlWebpackPlugin.options.baseHref %>">
+    <% } %>
+  </head>
+  <body>
+    <% if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
+    <style>.unsupported-browser { display: none; }</style>
+    <div class="unsupported-browser">
+      Sorry, your browser is not supported. Please upgrade to the latest version or switch your browser to use this
+      site. See <a href="http://outdatedbrowser.com/">outdatedbrowser.com</a> for options.
+    </div>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.scripts) { %>
-<% for (var script of htmlWebpackPlugin.options.scripts) { %>
-<script src="<%= script %>"></script>
-<% } %>
-<% } %>
+    <% if (htmlWebpackPlugin.options.appMountId) { htmlWebpackPlugin.options.appMountIds.unshift(htmlWebpackPlugin.options.appMountId) } %>
+    <% for (item of htmlWebpackPlugin.options.appMountIds) { %>
+    <div id="<%= item %>"></div>
+    <% } %>
 
-<% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
-<script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
-<% } %>
+    <% if (htmlWebpackPlugin.options.window) { %>
+    <script type="text/javascript">
+      <% for (key in htmlWebpackPlugin.options.window) { %>
+      window['<%= key %>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[key]) %>;
+      <% } %>
+    </script>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.devServer) { %>
-<script src="<%= htmlWebpackPlugin.options.devServer%>/webpack-dev-server.js"></script>
-<% } %>
+    <% for (item of htmlWebpackPlugin.options.scripts) { %>
+    <script src="<%= item %>" type="text/javascript"></script>
+    <% } %>
 
-<% if (htmlWebpackPlugin.options.googleAnalytics) { %>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <% for (key in htmlWebpackPlugin.files.chunks) { %>
+    <script src="<%= htmlWebpackPlugin.files.chunks[key].entry %>" type="text/javascript"></script>
+    <% } %>
 
+    <% if (htmlWebpackPlugin.options.devServer) { %>
+    <script src="<%= htmlWebpackPlugin.options.devServer %>/webpack-dev-server.js" type="text/javascript"></script>
+    <% } %>
 
-  <% if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
-    ga('create', '<%= htmlWebpackPlugin.options.googleAnalytics.trackingId%>', 'auto');
-    <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); }%>
-
-  <% if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
-    ga('send', 'pageview');
-  <% } %>
-</script>
-<% } %>
-</body>
+    <% if (htmlWebpackPlugin.options.googleAnalytics) { %>
+    <script type="text/javascript">
+      !function(o,n,f,a,t,e,r){o.GoogleAnalyticsObject=t,o[t]=o[t]||function(){(o[t].q=o[t].q||[]).push(arguments)},o[t].l=1*new Date,e=n.createElement(f),r=n.getElementsByTagName(f)[0],e.async=1,e.src=a,r.parentNode.insertBefore(e,r)}(window,document,"script","//www.google-analytics.com/analytics.js","ga")
+      <% if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
+      ga("create","<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>","auto")
+      <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); }%>
+      <% if (googleAnalytics.pageViewOnLoad) { %>
+      ga("send","pageview")
+      <% } %>
+    </script>
+    <% } %>
+  </body>
 </html>


### PR DESCRIPTION
# Notes

Because GitHub doesn't show line modification, like character insertions/deletions, the diff looks far more extensive than it really is.
1. In general, fixed indentation, spacing, and attribute order.
2. Added defaults for `appMountIds`, `links`, `meta`, and `scripts`. This allowed for the removal of some `if`s.
3. Added the X-UA-Compatible meta tag for IE.
4. Removed `||` for `title` because the option is provided by html-webpack-plugin (HWP). If the user doesn't set the option in their config, then HWP will set it to "Webpack App".
5. Made `links` section more concise to remove duplication.
6. To remove duplication, the `appMountId` is prepended to `appMountIds`.
7. The Google Analytics code was minified a bit further. It was run through an online version of UglifyJS 2.
