### PR TITLE
add support for inline-manifest-webpack-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ And some other optional:
     respectively.
 - `meta`: Object that defines the meta tags.
 - `mobile`: Sets appropriate meta tag for page scaling.
+- `inlineManifestWebpackName`: For use with [inline-manifest-webpack-plugin](https://www.npmjs.com/package/inline-manifest-webpack-plugin).
 - `scripts`: Array of external script imports to include on page.
   - If an array element is a string, the value is assigned to the `src` attribute and the `type` attribute is set to
     `"text/javascript"`;
@@ -91,6 +92,7 @@ Here's an example webpack config illustrating how to use these options in your `
           type: 'image/png'
         }
       ],
+      inlineManifestWebpackName: 'webpackManifest',
       scripts: [
         'http://example.com/somescript.js',
         {

--- a/index.ejs
+++ b/index.ejs
@@ -64,6 +64,10 @@
     </script>
     <% } %>
 
+    <% if (htmlWebpackPlugin.options.inlineManifestWebpackName) { %>
+        <%= htmlWebpackPlugin.files[htmlWebpackPlugin.options.inlineManifestWebpackName] %>
+    <% } %>
+
     <% for (item of htmlWebpackPlugin.options.scripts) { %>
     <% if (typeof item === 'string' || item instanceof String) { item = { src: item, type: 'text/javascript' } } %>
   	<script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script>


### PR DESCRIPTION
Trying to implement long-term caching via code splitting. To get this to work, I need to print the manifest file. See https://twitter.com/kentcdodds/status/759078941206261761 for more info.