### PR TITLE
Avoid mutating mount IDs array when rendering single mount ID

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -52,7 +52,9 @@
     </div>
     <% } %>
 
-    <% if (htmlWebpackPlugin.options.appMountId) { htmlWebpackPlugin.options.appMountIds.unshift(htmlWebpackPlugin.options.appMountId) } %>
+    <% if (htmlWebpackPlugin.options.appMountId) { %>
+    <div id="<%= htmlWebpackPlugin.options.appMountId %>"></div>
+    <% } %>
     <% for (item of htmlWebpackPlugin.options.appMountIds) { %>
     <div id="<%= item %>"></div>
     <% } %>


### PR DESCRIPTION
I'm running into some odd behavior when run in combination with `webpack-dev-server`.  In my configuration I specify a single `appMountId` for a React app.  When I run the dev server, the initial render is fine, but the `div` fixture appears an additional time whenever my scripts are recompiled and the template is rewritten, leading to something like:

```
...
<div id="fixture"></div>

<div id="fixture"></div>

<div id="fixture"></div>
...
```

This is because of an `unshift` call to the `appMountIds` array in the template.  This PR fixes the problem by rendering `appMountId` separately and not mutating the array.