### PR TITLE
Allows users to specify custom meta tags by converting the meta options from an object to an array of objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ And some other optional:
     `"stylesheet"`;
   - If an array element is an object, the object's properties and values are used as the attribute names and values,
     respectively.
-- `meta`: Object that defines the meta tags.
+- `meta`: Array of objects containing key value pairs to be included as meta tags. See the example config in this repo.
 - `mobile`: Sets appropriate meta tag for page scaling.
 - `inlineManifestWebpackName`: For use with [inline-manifest-webpack-plugin](https://www.npmjs.com/package/inline-manifest-webpack-plugin).
 - `scripts`: Array of external script imports to include on page.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ And some other optional:
     `"stylesheet"`;
   - If an array element is an object, the object's properties and values are used as the attribute names and values,
     respectively.
-- `meta`: Array of objects containing key value pairs to be included as meta tags. See the example config in this repo.
+- `meta`: Array of objects containing key value pairs to be included as meta tags.
 - `mobile`: Sets appropriate meta tag for page scaling.
 - `inlineManifestWebpackName`: For use with [inline-manifest-webpack-plugin](https://www.npmjs.com/package/inline-manifest-webpack-plugin).
 - `scripts`: Array of external script imports to include on page.

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -28,9 +28,12 @@ module.exports = {
         trackingId: 'UA-XXXX-XX',
         pageViewOnLoad: true
       },
-      meta: {
-        description: 'A better default template for html-webpack-plugin.'
-      },
+      meta: [
+        {
+          name: 'description',
+          content: 'A better default template for html-webpack-plugin.'
+        }
+      ],
       mobile: true,
       links: [
         'https://fonts.googleapis.com/css?family=Roboto',

--- a/index.ejs
+++ b/index.ejs
@@ -23,10 +23,6 @@
       <% for (item of htmlWebpackPlugin.options.meta) { %>
       <meta<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
       <% } %>
-    <% } else { %>
-      <% for (key in htmlWebpackPlugin.options.meta) { %>
-      <meta content="<%= htmlWebpackPlugin.options.meta[key] %>" name="<%= key %>">
-      <% } %>
     <% } %>
 
     <title><%= htmlWebpackPlugin.options.title %></title>

--- a/index.ejs
+++ b/index.ejs
@@ -2,7 +2,7 @@
 
 <% htmlWebpackPlugin.options.appMountIds = htmlWebpackPlugin.options.appMountIds || [] %>
 <% htmlWebpackPlugin.options.links = htmlWebpackPlugin.options.links || [] %>
-<% htmlWebpackPlugin.options.meta = htmlWebpackPlugin.options.meta || {} %>
+<% htmlWebpackPlugin.options.meta = htmlWebpackPlugin.options.meta || [] %>
 <% htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || [] %>
 
 <!DOCTYPE html>
@@ -19,8 +19,8 @@
     <base href="<%= htmlWebpackPlugin.options.baseHref %>">
     <% } %>
 
-    <% for (key in htmlWebpackPlugin.options.meta) { %>
-    <meta content="<%= htmlWebpackPlugin.options.meta[key] %>" name="<%= key %>">
+    <% for (item of htmlWebpackPlugin.options.meta) { %>
+    <meta<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
     <% } %>
 
     <title><%= htmlWebpackPlugin.options.title %></title>

--- a/index.ejs
+++ b/index.ejs
@@ -19,8 +19,14 @@
     <base href="<%= htmlWebpackPlugin.options.baseHref %>">
     <% } %>
 
-    <% for (item of htmlWebpackPlugin.options.meta) { %>
-    <meta<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
+    <% if (Array.isArray(htmlWebpackPlugin.options.meta)) { %>
+      <% for (item of htmlWebpackPlugin.options.meta) { %>
+      <meta<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
+      <% } %>
+    <% } else { %>
+      <% for (key in htmlWebpackPlugin.options.meta) { %>
+      <meta content="<%= htmlWebpackPlugin.options.meta[key] %>" name="<%= key %>">
+      <% } %>
     <% } %>
 
     <title><%= htmlWebpackPlugin.options.title %></title>


### PR DESCRIPTION
First of all, thank you for such an excellent package! I'm new to web dev, and really appreciate tools such as this that drastically simplify the learning experience.

The reason I'm making this request is because I am currently in a situation where I'd like to insert custom meta tags, and specify multiple attributes per tag. I found the template to be limiting in that respect, since it defaults to inserting the KV pairs from the meta object into a tag as the name and content of the new tag.

My new code simply adds a conditional in the template file that checks if the meta option from the webpack config is an array, and if it is, builds out a dynamic meta tag based on the KVP's in each object in the array. If not, it performs exactly the same as always, saving this update from breaking existing code.

Please let me know what you think! I'd love to see this go into production, especially since I would like to use this personally.