### PR TITLE
[REQUEST]: Add support for a custom HTML blob.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ And some other optional:
 - `meta`: Object that defines the meta tags.
 - `mobile`: Sets appropriate meta tag for page scaling.
 - `scripts`: Array of external script imports to include on page.
+  - If an array element is a string, the value is assigned to the `src` attribute and the `type` attribute is set to
+    `"text/javascript"`;
+  - If an array element is an object, the object's properties and values are used as the attribute names and values,
+    respectively.
 - `window`: Object that defines data you need to bootstrap a JavaScript app.
 
 Plus any [html-webpack-plugin config options](https://github.com/ampedandwired/html-webpack-plugin#configuration)
@@ -88,7 +92,11 @@ Here's an example webpack config illustrating how to use these options in your `
         }
       ],
       scripts: [
-        'http://example.com/somescript.js'
+        'http://example.com/somescript.js',
+        {
+          src: '/myModule.js',
+          type: 'module'
+        }
       ],
       title: 'My App',
       window: {

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ And some other optional:
 - `appMountId`: The `<div>` element id on which you plan to mount a JavaScript app.
 - `appMountIds`: An array of application element ids.
 - `baseHref`: Adjust the URL for relative URLs in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base)).
+- `content`: A string of html to embed within the `<body>` element.
 - `devServer`: Insert the webpack-dev-server hot reload script at this host:port/path; e.g., http://localhost:3000.
 - `googleAnalytics.trackingId`: Track usage of your site via [Google Analytics](http://analytics.google.com).
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
@@ -69,6 +70,7 @@ Here's an example webpack config illustrating how to use these options in your `
       // Optional
       appMountId: 'app',
       baseHref: 'http://example.com/awesome',
+      content: '<script type="application/json">{EMBEDDED_BY_SERVER_RENDER}</script>',
       devServer: 'http://localhost:3001',
       googleAnalytics: {
         trackingId: 'UA-XXXX-XX',

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ And some other optional:
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
 - `meta`: Object that defines the meta tags.
 - `mobile`: Sets appropriate meta tags for page scaling.
-- `links`: Array of external css imports to include on page.
+- `links`: Array of external `<link >` imports to include on page.
+  - If the array value is a string, the value is assigned to the `href` attribute and the `rel` attribute is set to `stylesheet`
+  - If the array value is an object, the object's properties and values are used as the attribute names and values.
 - `scripts`: Array of external script imports to include on page.
 - `title`: The title to use for the generated HTML document.
 - `window`: Object that defines data you need to bootstrap a javascript app.
@@ -67,7 +69,18 @@ Here's an example webpack config illustrating how to use these options in your `
       },
       mobile: true,
       links: [
-        'https://fonts.googleapis.com/css?family=Roboto"'
+        'https://fonts.googleapis.com/css?family=Roboto"',
+        {
+          rel: 'apple-touch-icon',
+          sizes: '180x180',
+          href: '/apple-touch-icon.png'
+        },
+        {
+          rel: 'icon',
+          type: 'image/png',
+          href: '/favicon-32x32.png',
+          sizes: '32x32'
+        }
       ],
       scripts: [
         'http://somecool.com/script.js'

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -31,7 +31,20 @@ module.exports = {
         trackingId: 'UA-XXXX-XX',
         pageViewOnLoad: true
       },
-      links: [ 'https://fonts.googleapis.com/css?family=Roboto"' ],
+      links: [ 
+        'https://fonts.googleapis.com/css?family=Roboto"',
+        {
+          rel: 'apple-touch-icon',
+          sizes: '180x180',
+          href: '/apple-touch-icon.png'
+        },
+        {
+          rel: 'icon',
+          type: 'image/png',
+          href: '/favicon-32x32.png',
+          sizes: '32x32'
+        } 
+      ],
       scripts: [ 'http://example.com/somescript.js' ],
       devServer: 'http://localhost:3001',
       appMountId: 'app',

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = {
           type: 'image/png'
         }
       ],
+      content: '<script type="application/json">{EMBEDDED_BY_SERVER_RENDER}</script>',
       scripts: [
         'http://example.com/somescript.js',
         {

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -47,7 +47,11 @@ module.exports = {
         }
       ],
       scripts: [
-        'http://example.com/somescript.js'
+        'http://example.com/somescript.js',
+        {
+          src: '/myModule.js',
+          type: 'module'
+        }
       ],
       title: 'My App',
       window: {

--- a/index.ejs
+++ b/index.ejs
@@ -67,7 +67,8 @@
     <% } %>
 
     <% for (item of htmlWebpackPlugin.options.scripts) { %>
-    <script src="<%= item %>" type="text/javascript"></script>
+    <% if (typeof item === 'string' || item instanceof String) { item = { src: item, type: 'text/javascript' } } %>
+  	<script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script>
     <% } %>
 
     <% for (key in htmlWebpackPlugin.files.chunks) { %>

--- a/index.ejs
+++ b/index.ejs
@@ -22,8 +22,16 @@
   <% } %>
 
   <% if (htmlWebpackPlugin.options.links) { %>
-  <% for (var link of htmlWebpackPlugin.options.links) { %>
-  <link href="<%= link %>" rel="stylesheet">
+  <% for(var link of htmlWebpackPlugin.options.links) { %>
+  <% if (link !== null && typeof link === 'object' ) { %>
+  <link
+    <% for (var key in link) { %>
+    <%= key %>="<%= link[key] %>"
+    <% } %>
+  >
+  <% } else { %>
+    <link href="<%= link %>" rel="stylesheet">
+  <% } %>
   <% } %>
   <% } %>
 

--- a/index.ejs
+++ b/index.ejs
@@ -61,6 +61,10 @@
     <div id="<%= item %>"></div>
     <% } %>
 
+    <% if (htmlWebpackPlugin.options.content) { %>
+    <%= htmlWebpackPlugin.options.content %>
+    <% } %>
+
     <% if (htmlWebpackPlugin.options.window) { %>
     <script type="text/javascript">
       <% for (key in htmlWebpackPlugin.options.window) { %>


### PR DESCRIPTION
My specific need is to use the generated `index.html` file as part of a server side rendering pipeline. Specifically, I'll need to bootstrap the page with JSON by replacing the text `{model}` in `<script type="application/json">{model}</script>` with a JSON blob.

My first idea was to enhance the `scripts` option to give special attention to an object with a `content` property. While `content` would be an invalid script attribute, it may still cause a backwards comparability issue if someone were emitting it for some purpose.

### Example 1
```javascript

{
  scripts: [
    {
      id: 'customData',
      type: 'application/json',
      content: '{model}',
    }
  ],
}

```

#### Generates

```html
<script id="customData" type="application/json">{model}</script>
```

You could potentially maintain backwards comparability by detecting a special structure like:

### Example 2

```javascript

{
  scripts: [
    {
      attributes: {
        id: 'customData',
        type: 'application/json',
      },
      content: '{model}',
    }
  ],
}

``` 

In order to avoid any backwards compatibility issues and to create an option that meets even more use cases, this pull request opts to go a much more generic route by simply allowing the user to define an open ended block of HTML as a string via a new option called `content`.

### Example 3

```javascript

{
  content: '<script id="customData" type="application/json">{model}</script>'
}

``` 

I placed it right below the rendered `appMountId` divs, but I could see this being controversial as it does cater to my specific use case and other users may want it rendered in different locations. I also realize you may not want to go this route as it deviates from the prescriptive/structured nature of the current template. Either way, I hope you understand the need and perhaps we can come up with a more ideal solution. Otherwise I can always customize it on my side. Thanks!