### PR TITLE
README: fix meta option to adhere to new structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ Here's an example webpack config illustrating how to use these options in your `
         trackingId: 'UA-XXXX-XX',
         pageViewOnLoad: true
       },
-      meta: {
-        description: 'A better default template for html-webpack-plugin.'
-      },
+      meta: [
+        {
+          name: 'description',
+          content: 'A better default template for html-webpack-plugin.'
+        }
+      ],
       mobile: true,
       links: [
         'https://fonts.googleapis.com/css?family=Roboto',


### PR DESCRIPTION
The new meta examples were only added to `examples/webpack.config.js` in #39.

Maybe remove this entire block from the README and simply refer to the `examples/webpack.config.js` file instead of duplicating examples to avoid mismatches?