### PR TITLE
Add support for Google Tag Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ And some other optional:
 - `devServer`: Insert the webpack-dev-server hot reload script at this host:port/path; e.g., http://localhost:3000.
 - `googleAnalytics.trackingId`: Track usage of your site via [Google Analytics](http://analytics.google.com).
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
+- `googleTagManager.containerId`: Container ID for use with [Google Tag Manager](https://www.google.com/analytics/tag-manager/).
+- `googleTagManager.dataLayerName`: A custom name to be used for the Google Tag Manager [dataLayer](https://developers.google.com/tag-manager/devguide). Defaults to 'dataLayer'. 
 - `lang`: String identifying your content language
 - `links`: Array of `<link>` elements.
   - If an array element is a string, the value is assigned to the `href` attribute and the `rel` attribute is set to

--- a/index.ejs
+++ b/index.ejs
@@ -24,6 +24,19 @@
 
     <title><%= htmlWebpackPlugin.options.title %></title>
 
+    <% if (htmlWebpackPlugin.options.googleTagManager) {
+         if (!htmlWebpackPlugin.options.googleTagManager.containerId) {
+           throw new Error("html-webpack-template requires googleTagManager.containerId config");
+         } %>
+    <script type="text/javascript">
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','<%= htmlWebpackPlugin.options.googleTagManager.dataLayerName || "dataLayer" %>', '<%= htmlWebpackPlugin.options.googleTagManager.containerId %>');
+    </script>
+    <% } %>
+
     <% if (htmlWebpackPlugin.files.favicon) { %>
     <link href="<%= htmlWebpackPlugin.files.favicon %>" rel="shortcut icon">
     <% } %>
@@ -43,6 +56,11 @@
 
   </head>
   <body>
+    <% if (htmlWebpackPlugin.options.googleTagManager) { %>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= htmlWebpackPlugin.options.googleTagManager.containerId %>"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <% } %>
+
     <% if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
     <style>.unsupported-browser { display: none; }</style>
     <div class="unsupported-browser">


### PR DESCRIPTION
Similar to current support for Google Analytics. Fixes jaketrent/html-webpack-template#52

For those not in the know, GTM can be used to inject Google Analytics and a number of other services. It allows our analytics and marketing people to easily add or remove tools as needed, and we've used it in the past for Google Analytics, Mixpanel, Intercom, etc. 