### PR TITLE
Add safari options to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ And some other optional:
   - If an array element is an object, the object's properties and values are used as the attribute names and values,
     respectively.
 - `window`: Object that defines data you need to bootstrap a JavaScript app.
+- `safari.title`: Custom launch icon title for [Mobile Safari](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html)
+- `safari.hideInterface`: Sets appropriate meta tag to [hide Mobile Safari UI](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html) when launched from an iOS home screen.
 
 Plus any [html-webpack-plugin config options](https://github.com/ampedandwired/html-webpack-plugin#configuration)
 otherwise available.
@@ -110,6 +112,10 @@ Here's an example webpack config illustrating how to use these options in your `
         env: {
           apiHost: 'http://myapi.com/api/v1'
         }
+      },
+      safari: {
+        title: "Launch My App",
+        hideInterface: true
       }
 
       // And any other config options from html-webpack-plugin:

--- a/index.ejs
+++ b/index.ejs
@@ -32,6 +32,16 @@
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <% } %>
 
+    <% if (htmlWebpackPlugin.options.safari) {%>
+      <% if (htmlWebpackPlugin.options.safari.hideInterface) {%>
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+      <% } %>
+      <% if (htmlWebpackPlugin.options.safari.title) {%>
+      <meta name="apple-mobile-web-app-title" content="<%= htmlWebpackPlugin.options.safari.title %>">
+      <% } %>
+    <% } %>
+
     <% for (item of htmlWebpackPlugin.options.links) { %>
     <% if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } %>
   	<link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>


### PR DESCRIPTION
This PR adds two options for configuring iOS' Safari [save-to-desktop](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html) feature, implemented in the template via an optional `safari` property on the existing `options` object.