### PR TITLE
Respect the same SRI checks that HWP supports via webpack-subresource-integrity

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -38,7 +38,15 @@
     <% } %>
 
     <% for (key in htmlWebpackPlugin.files.css) { %>
+    <% if (htmlWebpackPlugin.files.cssIntegrity) { %>
+    <link
+      href="<%= htmlWebpackPlugin.files.css[key] %>"
+      rel="stylesheet"
+      integrity="<%= htmlWebpackPlugin.files.cssIntegrity[key] %>"
+      crossorigin="<%= webpackConfig.output.crossOriginLoading %>">
+    <% } else { %>
     <link href="<%= htmlWebpackPlugin.files.css[key] %>" rel="stylesheet">
+    <% } %>
     <% } %>
 
   </head>
@@ -76,7 +84,15 @@
     <% } %>
 
     <% for (key in htmlWebpackPlugin.files.chunks) { %>
+    <% if (htmlWebpackPlugin.files.jsIntegrity) { %>
+    <script
+      src="<%= htmlWebpackPlugin.files.chunks[key].entry %>"
+      type="text/javascript"
+      integrity="<%= htmlWebpackPlugin.files.jsIntegrity[htmlWebpackPlugin.files.js.indexOf(htmlWebpackPlugin.files.chunks[key].entry)] %>"
+      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+    <% } else { %>
     <script src="<%= htmlWebpackPlugin.files.chunks[key].entry %>" type="text/javascript"></script>
+    <% } %>
     <% } %>
 
     <% if (htmlWebpackPlugin.options.devServer) { %>


### PR DESCRIPTION
html-webpack-plugin respects crossorigin and integrity attributes set on chunks via the webpack-subresource-integrity plugin. This PR attempts to support this as well by adding those attributes to script and link tags which can have integrity attributes.