### PR TITLE
Reduce whitespace and output raw HTML where appropriate

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -40,7 +40,7 @@
       <%_ } _%>
     <%_ } _%>
     <%_ if (htmlWebpackPlugin.options.headHtmlSnippet) { _%>
-    <%= htmlWebpackPlugin.options.headHtmlSnippet %>
+    <%- htmlWebpackPlugin.options.headHtmlSnippet %>
     <%_ } _%>
   </head>
   <body>
@@ -52,12 +52,12 @@
     </div>
     <%_ } _%>
     <%_ if (htmlWebpackPlugin.options.bodyHtmlSnippet) { _%>
-    <%= htmlWebpackPlugin.options.bodyHtmlSnippet %>
+    <%- htmlWebpackPlugin.options.bodyHtmlSnippet %>
     <%_ } _%>
     <%_ if (htmlWebpackPlugin.options.appMountId) { _%>
     <div id="<%= htmlWebpackPlugin.options.appMountId %>">
       <%_ if (htmlWebpackPlugin.options.appMountHtmlSnippet) { _%>
-      <%= htmlWebpackPlugin.options.appMountHtmlSnippet %>
+      <%- htmlWebpackPlugin.options.appMountHtmlSnippet %>
       <%_ } _%>
     </div>
     <%_ } _%>
@@ -67,7 +67,7 @@
     <%_ if (htmlWebpackPlugin.options.window) { _%>
     <script type="text/javascript">
       <%_ for (key in htmlWebpackPlugin.options.window) { _%>
-      window['<%= key %>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[key]) %>;
+      window['<%= key %>'] = <%- JSON.stringify(htmlWebpackPlugin.options.window[key]) %>;
       <%_ } _%>
     </script>
     <%_ } _%>

--- a/index.ejs
+++ b/index.ejs
@@ -1,127 +1,108 @@
-<% var item, key %>
-
-<% htmlWebpackPlugin.options.appMountIds = htmlWebpackPlugin.options.appMountIds || [] %>
-<% htmlWebpackPlugin.options.lang = htmlWebpackPlugin.options.lang || "en" %>
-<% htmlWebpackPlugin.options.links = htmlWebpackPlugin.options.links || [] %>
-<% htmlWebpackPlugin.options.meta = htmlWebpackPlugin.options.meta || [] %>
-<% htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || [] %>
-
+<% var item, key -%>
+<% htmlWebpackPlugin.options.appMountIds = htmlWebpackPlugin.options.appMountIds || [] -%>
+<% htmlWebpackPlugin.options.lang = htmlWebpackPlugin.options.lang || "en" -%>
+<% htmlWebpackPlugin.options.links = htmlWebpackPlugin.options.links || [] -%>
+<% htmlWebpackPlugin.options.meta = htmlWebpackPlugin.options.meta || [] -%>
+<% htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || [] -%>
 <!DOCTYPE html>
-<html lang="<%= htmlWebpackPlugin.options.lang %>" <% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>>
+<html lang="<%= htmlWebpackPlugin.options.lang %>"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>>
   <head>
     <meta charset="utf-8">
     <meta content="ie=edge" http-equiv="x-ua-compatible">
-
-    <% if (htmlWebpackPlugin.options.baseHref) { %>
+    <%_ if (htmlWebpackPlugin.options.baseHref) { _%>
     <base href="<%= htmlWebpackPlugin.options.baseHref %>">
-    <% } %>
-
-    <% if (Array.isArray(htmlWebpackPlugin.options.meta)) { %>
-      <% for (item of htmlWebpackPlugin.options.meta) { %>
-      <meta<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
-      <% } %>
-    <% } %>
-
+    <%_ } _%>
+    <%_ if (Array.isArray(htmlWebpackPlugin.options.meta)) { _%>
+      <%_ for (item of htmlWebpackPlugin.options.meta) { _%>
+    <meta<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
+      <%_ } _%>
+    <%_ } _%>
     <title><%= htmlWebpackPlugin.options.title %></title>
-
-    <% if (htmlWebpackPlugin.files.favicon) { %>
+    <%_ if (htmlWebpackPlugin.files.favicon) { _%>
     <link href="<%= htmlWebpackPlugin.files.favicon %>" rel="shortcut icon">
-    <% } %>
-
-    <% if (htmlWebpackPlugin.options.mobile) { %>
+    <%_ } _%>
+    <%_ if (htmlWebpackPlugin.options.mobile) { _%>
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <% } %>
-
-    <% for (item of htmlWebpackPlugin.options.links) { %>
-    <% if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } %>
-  	<link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
-    <% } %>
-
-    <% for (key in htmlWebpackPlugin.files.css) { %>
-    <% if (htmlWebpackPlugin.files.cssIntegrity) { %>
+    <%_ } _%>
+    <%_ for (item of htmlWebpackPlugin.options.links) { _%>
+      <%_ if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } _%>
+    <link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
+      <%_ } _%>
+    <%_ for (key in htmlWebpackPlugin.files.css) { _%>
+      <%_ if (htmlWebpackPlugin.files.cssIntegrity) { _%>
     <link
       href="<%= htmlWebpackPlugin.files.css[key] %>"
       rel="stylesheet"
       integrity="<%= htmlWebpackPlugin.files.cssIntegrity[key] %>"
       crossorigin="<%= webpackConfig.output.crossOriginLoading %>">
-    <% } else { %>
+      <%_ } else { _%>
     <link href="<%= htmlWebpackPlugin.files.css[key] %>" rel="stylesheet">
-    <% } %>
-    <% } %>
-    <% if (htmlWebpackPlugin.options.headHtmlSnippet) { %>
-      <%= htmlWebpackPlugin.options.headHtmlSnippet %>
-    <% } %>
+      <%_ } _%>
+    <%_ } _%>
+    <%_ if (htmlWebpackPlugin.options.headHtmlSnippet) { _%>
+    <%= htmlWebpackPlugin.options.headHtmlSnippet %>
+    <%_ } _%>
   </head>
   <body>
-    <% if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
+    <%_ if (htmlWebpackPlugin.options.unsupportedBrowser) { _%>
     <style>.unsupported-browser { display: none; }</style>
     <div class="unsupported-browser">
       Sorry, your browser is not supported. Please upgrade to the latest version or switch your browser to use this
       site. See <a href="http://outdatedbrowser.com/">outdatedbrowser.com</a> for options.
     </div>
-    <% } %>
-    <% if (htmlWebpackPlugin.options.bodyHtmlSnippet) { %>
-      <%= htmlWebpackPlugin.options.bodyHtmlSnippet %>
-    <% } %>
-    <% if (htmlWebpackPlugin.options.appMountId) { %>
-    <div id="<%= htmlWebpackPlugin.options.appMountId %>">	
-	
-		<% if (htmlWebpackPlugin.options.appMountHtmlSnippet) { %>
-		  <%= htmlWebpackPlugin.options.appMountHtmlSnippet %>
-		<% } %>
-	
-	</div>
-    <% } %>
-    <% for (item of htmlWebpackPlugin.options.appMountIds) { %>
+    <%_ } _%>
+    <%_ if (htmlWebpackPlugin.options.bodyHtmlSnippet) { _%>
+    <%= htmlWebpackPlugin.options.bodyHtmlSnippet %>
+    <%_ } _%>
+    <%_ if (htmlWebpackPlugin.options.appMountId) { _%>
+    <div id="<%= htmlWebpackPlugin.options.appMountId %>">
+      <%_ if (htmlWebpackPlugin.options.appMountHtmlSnippet) { _%>
+      <%= htmlWebpackPlugin.options.appMountHtmlSnippet %>
+      <%_ } _%>
+    </div>
+    <%_ } _%>
+    <%_ for (item of htmlWebpackPlugin.options.appMountIds) { _%>
     <div id="<%= item %>"></div>
-    <% } %>
-
-    <% if (htmlWebpackPlugin.options.window) { %>
+    <%_ } _%>
+    <%_ if (htmlWebpackPlugin.options.window) { _%>
     <script type="text/javascript">
-      <% for (key in htmlWebpackPlugin.options.window) { %>
+      <%_ for (key in htmlWebpackPlugin.options.window) { _%>
       window['<%= key %>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[key]) %>;
-      <% } %>
+      <%_ } _%>
     </script>
-    <% } %>
-
-    <% if (htmlWebpackPlugin.options.inlineManifestWebpackName) { %>
-        <%= htmlWebpackPlugin.files[htmlWebpackPlugin.options.inlineManifestWebpackName] %>
-    <% } %>
-
-    <% for (item of htmlWebpackPlugin.options.scripts) { %>
-    <% if (typeof item === 'string' || item instanceof String) { item = { src: item, type: 'text/javascript' } } %>
-  	<script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script>
-    <% } %>
-
-    <% for (key in htmlWebpackPlugin.files.chunks) { %>
-    <% if (htmlWebpackPlugin.files.jsIntegrity) { %>
+    <%_ } _%>
+    <%_ if (htmlWebpackPlugin.options.inlineManifestWebpackName) { _%>
+    <%= htmlWebpackPlugin.files[htmlWebpackPlugin.options.inlineManifestWebpackName] %>
+    <%_ } _%>
+    <%_ for (item of htmlWebpackPlugin.options.scripts) { _%>
+    <%_ if (typeof item === 'string' || item instanceof String) { item = { src: item, type: 'text/javascript' } } _%>
+    <script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script>
+    <%_ } _%>
+    <%_ for (key in htmlWebpackPlugin.files.chunks) { _%>
+      <%_ if (htmlWebpackPlugin.files.jsIntegrity) { _%>
     <script
       src="<%= htmlWebpackPlugin.files.chunks[key].entry %>"
       type="text/javascript"
       integrity="<%= htmlWebpackPlugin.files.jsIntegrity[htmlWebpackPlugin.files.js.indexOf(htmlWebpackPlugin.files.chunks[key].entry)] %>"
       crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
-    <% } else { %>
+      <%_ } else { _%>
     <script src="<%= htmlWebpackPlugin.files.chunks[key].entry %>" type="text/javascript"></script>
-    <% } %>
-    <% } %>
-
-    <% if (htmlWebpackPlugin.options.devServer) { %>
+      <%_ } _%>
+    <%_ } _%>
+    <%_ if (htmlWebpackPlugin.options.devServer) { _%>
     <script src="<%= htmlWebpackPlugin.options.devServer %>/webpack-dev-server.js" type="text/javascript"></script>
-    <% } %>
-
-    <% if (htmlWebpackPlugin.options.googleAnalytics) { %>
+    <%_ } _%>
+    <%_ if (htmlWebpackPlugin.options.googleAnalytics) { _%>
     <script type="text/javascript">
       window.GoogleAnalyticsObject='ga';window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
-
-      <% if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
+      <%_ if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { _%>
       ga('create','<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>','auto');
-      <% } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); } %>
-
-      <% if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
-      ga('send','pageview')
-      <% } %>
+      <%_ } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); } _%>
+      <%_ if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { _%>
+      ga('send','pageview');
+      <%_ } _%>
     </script>
     <script async defer src="https://www.google-analytics.com/analytics.js" type="text/javascript"></script>
-    <% } %>
+    <%_ } _%>
   </body>
 </html>

--- a/index.ejs
+++ b/index.ejs
@@ -33,7 +33,7 @@ htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || []
 
     for (item of htmlWebpackPlugin.options.links) { %><%
       if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } %>
-  	<link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>><%
+    <link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>><%
     } %><%
 
     for (key in htmlWebpackPlugin.files.css) { %><%
@@ -90,7 +90,7 @@ htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || []
 
     for (item of htmlWebpackPlugin.options.scripts) { %><%
       if (typeof item === 'string' || item instanceof String) { item = { src: item, type: 'text/javascript' } } %>
-  	<script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script><%
+    <script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script><%
     } %><%
 
     for (key in htmlWebpackPlugin.files.chunks) { %><%

--- a/index.ejs
+++ b/index.ejs
@@ -1,108 +1,127 @@
-<% var item, key -%>
-<% htmlWebpackPlugin.options.appMountIds = htmlWebpackPlugin.options.appMountIds || [] -%>
-<% htmlWebpackPlugin.options.lang = htmlWebpackPlugin.options.lang || "en" -%>
-<% htmlWebpackPlugin.options.links = htmlWebpackPlugin.options.links || [] -%>
-<% htmlWebpackPlugin.options.meta = htmlWebpackPlugin.options.meta || [] -%>
-<% htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || [] -%>
-<!DOCTYPE html>
+<% var item, key %><%
+htmlWebpackPlugin.options.appMountIds = htmlWebpackPlugin.options.appMountIds || [] %><%
+htmlWebpackPlugin.options.lang = htmlWebpackPlugin.options.lang || "en" %><%
+htmlWebpackPlugin.options.links = htmlWebpackPlugin.options.links || [] %><%
+htmlWebpackPlugin.options.meta = htmlWebpackPlugin.options.meta || [] %><%
+htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || []
+%><!DOCTYPE html>
 <html lang="<%= htmlWebpackPlugin.options.lang %>"<% if (htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>>
   <head>
     <meta charset="utf-8">
-    <meta content="ie=edge" http-equiv="x-ua-compatible">
-    <%_ if (htmlWebpackPlugin.options.baseHref) { _%>
-    <base href="<%= htmlWebpackPlugin.options.baseHref %>">
-    <%_ } _%>
-    <%_ if (Array.isArray(htmlWebpackPlugin.options.meta)) { _%>
-      <%_ for (item of htmlWebpackPlugin.options.meta) { _%>
-    <meta<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
-      <%_ } _%>
-    <%_ } _%>
-    <title><%= htmlWebpackPlugin.options.title %></title>
-    <%_ if (htmlWebpackPlugin.files.favicon) { _%>
-    <link href="<%= htmlWebpackPlugin.files.favicon %>" rel="shortcut icon">
-    <%_ } _%>
-    <%_ if (htmlWebpackPlugin.options.mobile) { _%>
-    <meta content="width=device-width, initial-scale=1" name="viewport">
-    <%_ } _%>
-    <%_ for (item of htmlWebpackPlugin.options.links) { _%>
-      <%_ if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } _%>
-    <link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
-      <%_ } _%>
-    <%_ for (key in htmlWebpackPlugin.files.css) { _%>
-      <%_ if (htmlWebpackPlugin.files.cssIntegrity) { _%>
+    <meta content="ie=edge" http-equiv="x-ua-compatible"><%
+
+    if (htmlWebpackPlugin.options.baseHref) { %>
+    <base href="<%= htmlWebpackPlugin.options.baseHref %>"><%
+    } %><%
+
+    if (Array.isArray(htmlWebpackPlugin.options.meta)) { %><%
+      for (item of htmlWebpackPlugin.options.meta) { %>
+    <meta<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>><%
+      } %><%
+    } %><%
+
+    %>
+    <title><%= htmlWebpackPlugin.options.title %></title><%
+
+    if (htmlWebpackPlugin.files.favicon) { %>
+    <link href="<%= htmlWebpackPlugin.files.favicon %>" rel="shortcut icon"><%
+    } %><%
+
+    if (htmlWebpackPlugin.options.mobile) { %>
+    <meta content="width=device-width, initial-scale=1" name="viewport"><%
+    } %><%
+
+    for (item of htmlWebpackPlugin.options.links) { %><%
+      if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } %>
+  	<link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>><%
+    } %><%
+
+    for (key in htmlWebpackPlugin.files.css) { %><%
+      if (htmlWebpackPlugin.files.cssIntegrity) { %>
     <link
       href="<%= htmlWebpackPlugin.files.css[key] %>"
       rel="stylesheet"
       integrity="<%= htmlWebpackPlugin.files.cssIntegrity[key] %>"
-      crossorigin="<%= webpackConfig.output.crossOriginLoading %>">
-      <%_ } else { _%>
-    <link href="<%= htmlWebpackPlugin.files.css[key] %>" rel="stylesheet">
-      <%_ } _%>
-    <%_ } _%>
-    <%_ if (htmlWebpackPlugin.options.headHtmlSnippet) { _%>
-    <%- htmlWebpackPlugin.options.headHtmlSnippet %>
-    <%_ } _%>
+      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"><%
+      } else { %>
+    <link href="<%= htmlWebpackPlugin.files.css[key] %>" rel="stylesheet"><%
+      } %><%
+    } %><%
+    if (htmlWebpackPlugin.options.headHtmlSnippet) { %>
+    <%= htmlWebpackPlugin.options.headHtmlSnippet %><%
+    } %>
   </head>
-  <body>
-    <%_ if (htmlWebpackPlugin.options.unsupportedBrowser) { _%>
+  <body><%
+    if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
     <style>.unsupported-browser { display: none; }</style>
     <div class="unsupported-browser">
       Sorry, your browser is not supported. Please upgrade to the latest version or switch your browser to use this
       site. See <a href="http://outdatedbrowser.com/">outdatedbrowser.com</a> for options.
-    </div>
-    <%_ } _%>
-    <%_ if (htmlWebpackPlugin.options.bodyHtmlSnippet) { _%>
-    <%- htmlWebpackPlugin.options.bodyHtmlSnippet %>
-    <%_ } _%>
-    <%_ if (htmlWebpackPlugin.options.appMountId) { _%>
-    <div id="<%= htmlWebpackPlugin.options.appMountId %>">
-      <%_ if (htmlWebpackPlugin.options.appMountHtmlSnippet) { _%>
-      <%- htmlWebpackPlugin.options.appMountHtmlSnippet %>
-      <%_ } _%>
-    </div>
-    <%_ } _%>
-    <%_ for (item of htmlWebpackPlugin.options.appMountIds) { _%>
-    <div id="<%= item %>"></div>
-    <%_ } _%>
-    <%_ if (htmlWebpackPlugin.options.window) { _%>
-    <script type="text/javascript">
-      <%_ for (key in htmlWebpackPlugin.options.window) { _%>
-      window['<%= key %>'] = <%- JSON.stringify(htmlWebpackPlugin.options.window[key]) %>;
-      <%_ } _%>
-    </script>
-    <%_ } _%>
-    <%_ if (htmlWebpackPlugin.options.inlineManifestWebpackName) { _%>
-    <%= htmlWebpackPlugin.files[htmlWebpackPlugin.options.inlineManifestWebpackName] %>
-    <%_ } _%>
-    <%_ for (item of htmlWebpackPlugin.options.scripts) { _%>
-    <%_ if (typeof item === 'string' || item instanceof String) { item = { src: item, type: 'text/javascript' } } _%>
-    <script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script>
-    <%_ } _%>
-    <%_ for (key in htmlWebpackPlugin.files.chunks) { _%>
-      <%_ if (htmlWebpackPlugin.files.jsIntegrity) { _%>
+    </div><%
+    } %><%
+
+    if (htmlWebpackPlugin.options.bodyHtmlSnippet) { %>
+    <%= htmlWebpackPlugin.options.bodyHtmlSnippet %><%
+    } %><%
+
+    if (htmlWebpackPlugin.options.appMountId) { %>
+    <div id="<%= htmlWebpackPlugin.options.appMountId %>"><%
+      if (htmlWebpackPlugin.options.appMountHtmlSnippet) { %>
+    <%= htmlWebpackPlugin.options.appMountHtmlSnippet %><%
+      } %>
+    </div><%
+    } %><%
+
+    for (item of htmlWebpackPlugin.options.appMountIds) { %>
+    <div id="<%= item %>"></div><%
+    } %><%
+
+    if (htmlWebpackPlugin.options.window) { %>
+    <script type="text/javascript"><%
+      for (key in htmlWebpackPlugin.options.window) { %>
+      window['<%= key %>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[key]) %>;<%
+      } %>
+    </script><%
+    } %><%
+
+    if (htmlWebpackPlugin.options.inlineManifestWebpackName) { %>
+    <%= htmlWebpackPlugin.files[htmlWebpackPlugin.options.inlineManifestWebpackName] %><%
+    } %><%
+
+    for (item of htmlWebpackPlugin.options.scripts) { %><%
+      if (typeof item === 'string' || item instanceof String) { item = { src: item, type: 'text/javascript' } } %>
+  	<script<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>></script><%
+    } %><%
+
+    for (key in htmlWebpackPlugin.files.chunks) { %><%
+      if (htmlWebpackPlugin.files.jsIntegrity) { %>
     <script
       src="<%= htmlWebpackPlugin.files.chunks[key].entry %>"
       type="text/javascript"
       integrity="<%= htmlWebpackPlugin.files.jsIntegrity[htmlWebpackPlugin.files.js.indexOf(htmlWebpackPlugin.files.chunks[key].entry)] %>"
-      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
-      <%_ } else { _%>
-    <script src="<%= htmlWebpackPlugin.files.chunks[key].entry %>" type="text/javascript"></script>
-      <%_ } _%>
-    <%_ } _%>
-    <%_ if (htmlWebpackPlugin.options.devServer) { _%>
-    <script src="<%= htmlWebpackPlugin.options.devServer %>/webpack-dev-server.js" type="text/javascript"></script>
-    <%_ } _%>
-    <%_ if (htmlWebpackPlugin.options.googleAnalytics) { _%>
+      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script><%
+      } else { %>
+    <script src="<%= htmlWebpackPlugin.files.chunks[key].entry %>" type="text/javascript"></script><%
+      } %><%
+    } %><%
+
+    if (htmlWebpackPlugin.options.devServer) { %>
+    <script src="<%= htmlWebpackPlugin.options.devServer %>/webpack-dev-server.js" type="text/javascript"></script><%
+    } %><%
+
+    if (htmlWebpackPlugin.options.googleAnalytics) { %>
     <script type="text/javascript">
-      window.GoogleAnalyticsObject='ga';window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
-      <%_ if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { _%>
-      ga('create','<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>','auto');
-      <%_ } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); } _%>
-      <%_ if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { _%>
-      ga('send','pageview');
-      <%_ } _%>
+      window.GoogleAnalyticsObject='ga';window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;<%
+
+      if (htmlWebpackPlugin.options.googleAnalytics.trackingId) { %>
+      ga('create','<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>','auto');<%
+      } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); } %><%
+
+      if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
+      ga('send','pageview')<%
+      } %>
     </script>
-    <script async defer src="https://www.google-analytics.com/analytics.js" type="text/javascript"></script>
-    <%_ } _%>
+    <script async defer src="https://www.google-analytics.com/analytics.js" type="text/javascript"></script><%
+    } %>
   </body>
 </html>


### PR DESCRIPTION
The initial goal of this PR was to reduce the whitespace in the generated HTML, however while plugging in values to test my changes, I noticed the following issues:

- `headHtmlSnippet`, `bodyHtmlSnippet` and `appMountHtmlSnippet` were being output with `<%= ... %>`, which meant that HTML was being escaped—so `<div>whatever</div>` was being turned into something like `&lt;div&gt;whatever&lt;/div&gt;`. This seemed unintentional, so I changed the tag to `<%- ... %>`, which allows raw HTML.
- `window` vars were also being escaped by the `<%= ... %>` tag. This meant that `"window": { "global1": "test" }"` was being converted to `window['global1'] = &#34;test&#34;;`—a syntax error. I also changed this tag to `<%- ... %>`.

Both of these changes are contained in a separate commit, so I can make a new PR just for them, if you'd like.

Anyhow, onto the actual purpose of this PR: reducing whitespace. Here's the output before, with no options:

![html-webpack-template-before](https://user-images.githubusercontent.com/1534628/36079984-f75c1676-0f4e-11e8-86a9-16650e544c93.png)

And here's after:

![html-webpack-after](https://user-images.githubusercontent.com/1534628/36079986-fc37bdda-0f4e-11e8-9591-1444bfb8ec54.png)
