### PR TITLE
Add google analytics anonymize ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ To make it work, you need to provide these **required parameters**:
 
 And you can provide some other *optional parameters*:
 - `appMountId`: The `<div>` element id on which you plan to mount a JavaScript app.
-- `appMountHtmlSnippet`: A small snippet of HTML that will be inserted in the `<div>` element the appMountId is attached to. 
+- `appMountHtmlSnippet`: A small snippet of HTML that will be inserted in the `<div>` element the appMountId is attached to.
 - `appMountIds`: An array of application element ids.
 - `baseHref`: Adjust the URL for relative URLs in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base)).
 - `devServer`: Insert the webpack-dev-server hot reload script at this host:port/path; e.g., http://localhost:3000.
 - `googleAnalytics.trackingId`: Track usage of your site via [Google Analytics](http://analytics.google.com).
+- `googleAnalytics.anonymizeIp`: Anonymize tracking of IP statistics [IP Anonymization in Analytics](https://support.google.com/analytics/answer/2763052).
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
 - `lang`: String identifying your content language
 - `links`: Array of `<link>` elements.
@@ -50,8 +51,8 @@ And you can provide some other *optional parameters*:
   - If an array element is an object, the object's properties and values are used as the attribute names and values,
     respectively.
 - `window`: Object that defines data you need to bootstrap a JavaScript app.
-- `headHtmlSnippet`: A small snippet of HTML that will be inserted in the head element. 
-- `bodyHtmlSnippet`: A small snippet of HTML that will be inserted in the body element. 
+- `headHtmlSnippet`: A small snippet of HTML that will be inserted in the head element.
+- `bodyHtmlSnippet`: A small snippet of HTML that will be inserted in the body element.
 
 Plus any [html-webpack-plugin config options](https://github.com/ampedandwired/html-webpack-plugin#configuration)
 otherwise available.
@@ -79,6 +80,7 @@ Here's an example webpack config illustrating how to use these options in your `
       devServer: 'http://localhost:3001',
       googleAnalytics: {
         trackingId: 'UA-XXXX-XX',
+        anonymizeIp: false,
         pageViewOnLoad: true
       },
       meta: [

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ And you can provide some other *optional parameters*:
 - `baseHref`: Adjust the URL for relative URLs in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base)).
 - `devServer`: Insert the webpack-dev-server hot reload script at this host:port/path; e.g., http://localhost:3000.
 - `googleAnalytics.trackingId`: Track usage of your site via [Google Analytics](http://analytics.google.com).
-- `googleAnalytics.anonymizeIp`: Anonymize tracking of IP statistics [IP Anonymization in Analytics](https://support.google.com/analytics/answer/2763052).
+- `googleAnalytics.anonymizeIp`: Anonymize tracking of IP statistics ([IP Anonymization in Analytics](https://support.google.com/analytics/answer/2763052)).
 - `googleAnalytics.pageViewOnLoad`: Log a `pageview` event after the analytics code loads.
 - `lang`: String identifying your content language
 - `links`: Array of `<link>` elements.

--- a/index.ejs
+++ b/index.ejs
@@ -117,8 +117,12 @@ htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || []
       ga('create','<%= htmlWebpackPlugin.options.googleAnalytics.trackingId %>','auto');<%
       } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); } %><%
 
+      if (htmlWebpackPlugin.options.googleAnalytics.anonymizeIp) { %>
+      ga('set', 'anonymizeIp', true);<%
+      } %>
+
       if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
-      ga('send','pageview')<%
+      ga('send','pageview');<%
       } %>
     </script>
     <script async defer src="https://www.google-analytics.com/analytics.js" type="text/javascript"></script><%

--- a/index.ejs
+++ b/index.ejs
@@ -118,8 +118,8 @@ htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || []
       } else { throw new Error("html-webpack-template requires googleAnalytics.trackingId config"); } %><%
 
       if (htmlWebpackPlugin.options.googleAnalytics.anonymizeIp) { %>
-      ga('set', 'anonymizeIp', true);<%
-      } %>
+      ga('set','anonymizeIp',true);<%
+      } %><%
 
       if (htmlWebpackPlugin.options.googleAnalytics.pageViewOnLoad) { %>
       ga('send','pageview');<%


### PR DESCRIPTION
Add new `googleAnalytics.anonymizeIp` option to anonymize IP statistic gathering in Google Analytics tracking (https://support.google.com/analytics/answer/2763052).  This is becoming more common for GDPR compliance (https://en.wikipedia.org/wiki/General_Data_Protection_Regulation).