### PR TITLE
feat: new optional parameter appMountAttrs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ To make it work, you need to provide these **required parameters**:
 
 And you can provide some other *optional parameters*:
 - `appMountId`: The `<div>` element id on which you plan to mount a JavaScript app.
+- `appMountAttrs`: The `<div>` element other attributes that you want to add 
+  (eg `aria-hidden="true"` to solve [ayy1 errors](https://dequeuniversity.com/rules/axe/3.5/region)).
+  Note that appMountId is required.
 - `appMountHtmlSnippet`: A small snippet of HTML that will be inserted in the `<div>` element the appMountId is attached to. 
 - `appMountIds`: An array of application element ids.
 - `baseHref`: Adjust the URL for relative URLs in the document ([MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/base)).

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
       inject: false,
       template: '../index.ejs',
       appMountId: 'app',
+      appMountAttrs: 'aria-hidden="true"',
       devServer: 'http://localhost:3001',
       googleAnalytics: {
         trackingId: 'UA-XXXX-XX',

--- a/index.ejs
+++ b/index.ejs
@@ -65,7 +65,11 @@ htmlWebpackPlugin.options.scripts = htmlWebpackPlugin.options.scripts || []
     } %><%
 
     if (htmlWebpackPlugin.options.appMountId) { %>
-    <div id="<%= htmlWebpackPlugin.options.appMountId %>"><%
+    <div id="<%= htmlWebpackPlugin.options.appMountId %>" <%
+      if (htmlWebpackPlugin.options.appMountAttrs) { %>
+        <%= htmlWebpackPlugin.options.appMountAttrs %>
+      <% } %>
+    > <%
       if (htmlWebpackPlugin.options.appMountHtmlSnippet) { %>
     <%= htmlWebpackPlugin.options.appMountHtmlSnippet %><%
       } %>


### PR DESCRIPTION
Allowing the user to set custom html attributes to the app mount div.

I added this to solve the axe accessibility issue [All page content must be contained by landmarks](https://dequeuniversity.com/rules/axe/3.5/region), specifying that all top html elements must be landmark elements
```html
<html lang="en">
    <head>
        <title>Hello</title>
    </head>
    <body>
        <header>This is the header</header>
        <nav>This is the nav</nav>
        <main>This is the main</main>
        <footer>This is the footer</footer>
    </body>
</html>
```

In our case with react and html-webpack-template, the structure becomes:
```html
<html lang="en">
    <head>
        <title>Hello</title>
    </head>
    <body>
        <!-- add the aria-hidden="true" attribute for screen readers to ignore that element -->
        <div id="root" aria-hidden="true">
            <header>This is the header</header>
            <nav>This is the nav</nav>
            <main>This is the main</main>
            <footer>This is the footer</footer>
        </div>
    </body>
</html>
```